### PR TITLE
fix: deb: create subfolders and use GNU tar format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ TEST_OPTIONS?=
 setup:
 	go get -u github.com/alecthomas/gometalinter
 	go get -u github.com/golang/dep/cmd/dep
-	go get -u github.com/pierrre/gotestcover
 	go get -u golang.org/x/tools/cmd/cover
 	go get -u github.com/caarlos0/bandep
 	go get -u github.com/gobuffalo/packr/...
@@ -22,7 +21,7 @@ check:
 
 # Run all the tests
 test:
-	gotestcover $(TEST_OPTIONS) -covermode=atomic -coverprofile=coverage.txt $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=2m
+	go test $(TEST_OPTIONS) -v -coverpkg=./... -race -failfast -covermode=atomic -coverprofile=coverage.txt $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=2m
 .PHONY: cover
 
 # Run all the tests and opens the coverage report

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -116,6 +116,7 @@ func createTree(tarw *tar.Writer, dst string) error {
 			Mode:     0755,
 			Typeflag: tar.TypeDir,
 			Format:   tar.FormatGNU,
+			ModTime:  time.Now(),
 		}); err != nil {
 			return errors.Wrap(err, "failed to create folder")
 		}

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -143,7 +143,7 @@ func pathsToCreate(dst string) []string {
 		paths = append(paths, base)
 	}
 	// we don't really need to create those things in order apparently, but,
-	// it looks really weird if we dont.
+	// it looks really weird if we do.
 	var result []string
 	for i := len(paths) - 1; i >= 0; i-- {
 		result = append(result, paths[i])

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -129,3 +129,11 @@ func TestConffiles(t *testing.T) {
 	})
 	assert.Equal(t, "/etc/fake\n", string(out), "should have a trailing empty line")
 }
+
+func TestPathsToCreate(t *testing.T) {
+	assert.Equal(
+		t,
+		[]string{"usr", "usr/share", "usr/share/doc", "usr/share/doc/whatever"},
+		pathsToCreate("/usr/share/doc/whatever/foo.md"),
+	)
+}

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -3,6 +3,7 @@ package deb
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -41,7 +42,8 @@ var info = nfpm.WithDefaults(nfpm.Info{
 	Homepage:    "http://carlosbecker.com",
 	Vendor:      "nope",
 	Files: map[string]string{
-		"../testdata/fake": "/usr/local/bin/fake",
+		"../testdata/fake":          "/usr/local/bin/fake",
+		"../testdata/whatever.conf": "/usr/share/doc/fake/fake.txt",
 	},
 	ConfigFiles: map[string]string{
 		"../testdata/whatever.conf": "/etc/fake/fake.conf",
@@ -131,9 +133,13 @@ func TestConffiles(t *testing.T) {
 }
 
 func TestPathsToCreate(t *testing.T) {
-	assert.Equal(
-		t,
-		[]string{"usr", "usr/share", "usr/share/doc", "usr/share/doc/whatever"},
-		pathsToCreate("/usr/share/doc/whatever/foo.md"),
-	)
+	for path, parts := range map[string][]string{
+		"/usr/share/doc/whatever/foo.md": []string{"usr", "usr/share", "usr/share/doc", "usr/share/doc/whatever"},
+		"/var/moises":                    []string{"var"},
+		"/":                              []string{},
+	} {
+		t.Run(fmt.Sprintf("path: '%s'", path), func(t *testing.T) {
+			assert.Equal(t, parts, pathsToCreate(path))
+		})
+	}
 }


### PR DESCRIPTION
closes #6 

tl;dr: the problem was in the `data.tar.gz`, which had only the files, but not the folders themselves.

I had to walk through the desired path and create the headers inside the tar file, which fixes the issue as it seems.

```
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/bin/
-rwxr-xr-x  0 0      0     1034959 Feb 25 14:58 usr/bin/rclone
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/share/
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/share/doc/
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/share/doc/rclone/
-rw-r--r--  0 0      0        3267 Feb 25 14:58 usr/share/doc/rclone/README.txt
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/share/
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/share/man/
drwxr-xr-x  0 0      0           0 Dec 31  1969 usr/share/man/man1/
-rw-r--r--  0 0      0      355170 Feb 25 14:58 usr/share/man/man1/rclone.1
```

before that , we had:

```
-rwxr-xr-x  0 0      0     1034959 Feb 25 14:58 usr/bin/rclone
-rw-r--r--  0 0      0        3267 Feb 25 14:58 usr/share/doc/rclone/README.txt
-rw-r--r--  0 0      0      355170 Feb 25 14:58 usr/share/man/man1/rclone.1
```

as a bonus, I also changed the format of the headers to GNU format.

--- 

TODO: 

- [x] avoid duplicating the paths (`usr/` header is added several times)
- [x] betere cover it with tests