### PR TITLE
Provide default value for Description field

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -67,6 +67,9 @@ func WithDefaults(info Info) Info {
 	if info.Platform == "" {
 		info.Platform = "linux"
 	}
+	if info.Description == "" {
+		info.Description = "no description given"
+	}
 	info.Version = strings.TrimPrefix(info.Version, "v")
 	return info
 }

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -41,9 +41,10 @@ func TestDefaultsOnEmptyInfo(t *testing.T) {
 
 func TestDefaults(t *testing.T) {
 	info := Info{
-		Bindir:   "/usr/bin",
-		Platform: "darwin",
-		Version:  "2.4.1",
+		Bindir:      "/usr/bin",
+		Platform:    "darwin",
+		Version:     "2.4.1",
+		Description: "no description given",
 	}
 	got := WithDefaults(info)
 	assert.Equal(t, info, got)


### PR DESCRIPTION
I've just hit an issue where `dpkg` was failing to process the Debian control file generated by `nfpm`. 

```
dpkg: error processing archive /var/cache/apt/archives/testpackage_0.0.1_amd64.deb (--unpack):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 9 package 'testpackage':
 end of file before value of field 'Description' (missing final newline)
Errors were encountered while processing:
 /var/cache/apt/archives/testpackage_0.0.1_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

This behavior can be reproduced by not providing a Description value, which according to the [official specs](https://www.debian.org/doc/debian-policy/#the-description-of-a-package), every Debian package must have one.

Of course this can be worked around by actually giving a description, which I did so, and as much as I favor this solution given the technical spec's requirement, by not having this creates a breaking change in GoReleaser since it now uses `nfpm` by default even though this behavior doesn't mirror those in `fpm`.

But I'd like to propose having the same default value as `fpm` which is setting the default message to the value: "no description given". See: https://github.com/jordansissel/fpm/blob/8f2dd4516acf6639ec2410f6fc7f20b58a04c2ef/lib/fpm/package.rb#L151