### PR TITLE
add: Add arm6 and arm7 support to deb package

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -29,6 +29,8 @@ func init() {
 var goarchToDebian = map[string]string{
 	"386":    "i386",
 	"arm":    "armhf",
+	"arm6":   "armel",
+	"arm7":   "armhf",
 	"mipsle": "mipsel",
 }
 


### PR DESCRIPTION
To be able to build arm6 and arm7 packages, added required
architectures to the goarchToDebian mapping.