### PR TITLE
docs: Add overrides section to example config

### DIFF
--- a/cmd/nfpm/main.go
+++ b/cmd/nfpm/main.go
@@ -116,4 +116,13 @@ files:
   ./bar: "/usr/local/bin/bar"
 config_files:
   ./foobar.conf: "/etc/foobar.conf"
+overrides:
+  rpm:
+    scripts:
+      preinstall: ./scripts/preinstall.sh
+      postremove: ./scripts/postremove.sh
+  deb:
+    scripts:
+      postinstall: ./scripts/postinstall.sh
+      preremove: ./scripts/preremove.sh
 `


### PR DESCRIPTION
I noticed that the new feature of pre- und postinstall scripts isn't
reflected in the output of the example config file. This commit adds the
missing parts to make it clearer that this feature is available.

See #19