### PR TITLE
Added Environment Support for version

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -42,6 +42,9 @@ func Parse(in io.Reader) (config Config, err error) {
 	if err = dec.Decode(&config); err != nil {
 		return
 	}
+	if strings.HasPrefix(config.Info.Version, "$") {
+		config.Info.Version = os.Getenv(strings.TrimLeft(config.Info.Version, "$"))
+	}
 	err = config.Validate()
 	return
 }


### PR DESCRIPTION
With this patch it is possible to use enviornment variables for the versions value in the yaml file:

```version: $NFPM_PACKAGE_VERSION```

The reason for this is automated builds. With Environment support for Version value I dont need to render the yaml file each time.