### PR TITLE
deb: Avoid emitting empty fields

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -327,13 +327,20 @@ func conffiles(info nfpm.Info) []byte {
 	return []byte(strings.Join(confs, "\n") + "\n")
 }
 
-var controlTemplate = `Package: {{.Info.Name}}
+var controlTemplate = `
+{{- /* Mandatory fields */ -}}
+Package: {{.Info.Name}}
 Version: {{.Info.Version}}
 Section: {{.Info.Section}}
 Priority: {{.Info.Priority}}
 Architecture: {{.Info.Arch}}
+{{- /* Optional fields */ -}}
+{{- if .Info.Maintainer}}
 Maintainer: {{.Info.Maintainer}}
+{{- end }}
+{{- if .Info.Vendor}}
 Vendor: {{.Info.Vendor}}
+{{- end }}
 Installed-Size: {{.InstalledSize}}
 {{- with .Info.Replaces}}
 Replaces: {{join .}}
@@ -353,7 +360,10 @@ Suggests: {{join .}}
 {{- with .Info.Conflicts}}
 Conflicts: {{join .}}
 {{- end }}
+{{- if .Info.Homepage}}
 Homepage: {{.Info.Homepage}}
+{{- end }}
+{{- /* Mandatory fields */}}
 Description: {{.Info.Description}}
 `
 

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -228,3 +228,24 @@ func TestPathsToCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestMinimalFields(t *testing.T) {
+	var w bytes.Buffer
+	assert.NoError(t, writeControl(&w, controlData{
+		Info: nfpm.WithDefaults(nfpm.Info{
+			Name:        "minimal",
+			Arch:        "arm64",
+			Description: "Minimal does nothing",
+			Priority:    "extra",
+			Version:     "1.0.0",
+			Section:     "default",
+		}),
+	}))
+	var golden = "testdata/minimal.golden"
+	if *update {
+		require.NoError(t, ioutil.WriteFile(golden, w.Bytes(), 0655))
+	}
+	bts, err := ioutil.ReadFile(golden) //nolint:gosec
+	assert.NoError(t, err)
+	assert.Equal(t, string(bts), w.String())
+}

--- a/deb/testdata/minimal.golden
+++ b/deb/testdata/minimal.golden
@@ -1,0 +1,7 @@
+Package: minimal
+Version: 1.0.0
+Section: default
+Priority: extra
+Architecture: arm64
+Installed-Size: 0
+Description: Minimal does nothing


### PR DESCRIPTION
The Debian policy[1] declares the following control file fields as
required for binary packages:

 * Package
 * Version
 * Section
 * Priority
 * Architecture
 * Maintainer
 * Description

All other fields are optional. A few programs handling .deb packages
emit warnings when optional fields exist without a value.

With this change the template generating the control file is updated to
omit empty values. Comments are added to denote mandatory fields.
A newly added test verifies the generated control file.

[1]
<https://www.debian.org/doc/debian-policy/ch-controlfields.html#binary-package-control-files-debian-control>