### PR TITLE
feat: rpm compatible arch for ppc64/ppc64le

### DIFF
--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -26,12 +26,6 @@ func init() {
 	nfpm.Register("rpm", Default)
 }
 
-// nolint: gochecknoglobals
-var goarchToRPM = map[string]string{
-	"amd64": "x86_64",
-	"386":   "i386",
-}
-
 // Default deb packager
 // nolint: gochecknoglobals
 var Default = &RPM{}
@@ -39,12 +33,24 @@ var Default = &RPM{}
 // RPM is a RPM packager implementation
 type RPM struct{}
 
+// GoArchToRpm converts a goarch to an RPM compatible arch
+func GoArchToRpm(goArch string) string {
+	switch {
+	case strings.Contains(goArch, "amd64"):
+		return "x86_64"
+	case strings.Contains(goArch, "386"):
+		return "i386"
+	case strings.Contains(goArch, "ppc64le"):
+		return "ppc64le"
+	case strings.Contains(goArch, "ppc64"):
+		return "ppc64"
+	}
+	return goArch
+}
+
 // Package writes a new RPM package to the given writer using the given info
 func (*RPM) Package(info nfpm.Info, w io.Writer) error {
-	arch, ok := goarchToRPM[info.Arch]
-	if ok {
-		info.Arch = arch
-	}
+	info.Arch = GoArchToRpm(info.Arch)
 	info.Version = strings.Replace(info.Version, "-", "_", -1)
 	_, err := exec.LookPath("rpmbuild")
 	if err != nil {


### PR DESCRIPTION
Updated nfpm to perform a mapping to appropriate architectures for the
POWER big and little endian architectures.

Note that I also made some changes to unrelated tests to make the linter happy. 