### PR TITLE
issue46: Add support for a Release flag

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -107,6 +107,7 @@ type Info struct {
 	Arch         string `yaml:"arch,omitempty"`
 	Platform     string `yaml:"platform,omitempty"`
 	Version      string `yaml:"version,omitempty"`
+	Release      string `yaml:"release,omitempty"`
 	Section      string `yaml:"section,omitempty"`
 	Priority     string `yaml:"priority,omitempty"`
 	Maintainer   string `yaml:"maintainer,omitempty"`

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -50,6 +50,9 @@ func (*RPM) Package(info nfpm.Info, w io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("rpmbuild not present in $PATH")
 	}
+	if s := info.Release; s == "" {
+		info.Release = "1"
+	}
 	temps, err := setupTempFiles(info)
 	if err != nil {
 		return err
@@ -219,7 +222,7 @@ func setupTempFiles(info nfpm.Info) (tempFiles, error) {
 		Folder: folder,
 		Source: filepath.Join(root, "SOURCES", folder+".tar.gz"),
 		Spec:   filepath.Join(root, "SPECS", info.Name+".spec"),
-		RPM:    filepath.Join(root, "RPMS", info.Arch, fmt.Sprintf("%s-1.%s.rpm", folder, info.Arch)),
+		RPM:    filepath.Join(root, "RPMS", info.Arch, fmt.Sprintf("%s-%s.%s.rpm", folder, info.Release, info.Arch)),
 	}, nil
 }
 
@@ -313,7 +316,7 @@ const specTemplate = `
 Name: {{ .Info.Name }}
 Summary: {{ first_line .Info.Description }}
 Version: {{ .Info.Version }}
-Release: 1
+Release: {{ .Info.Release }}
 {{- with .Info.License }}
 License: {{ . }}
 {{- end }}


### PR DESCRIPTION
This patch adds support for specifying an rpm Release flag other than the default '1'.

```
$ head -5 nfpm.yaml
name: "csync"
arch: "amd64"
platform: "linux"
version: "1.0.0"
release: "2"

$ make rpm
nfpm pkg --target csync-"1.0.0"-"2".x86_64.rpm
using rpm packager...
created package: csync-1.0.0-2.x86_64.rpm

$ rpm -qip ./csync-1.0.0-2.x86_64.rpm | head -5
Name        : csync
Version     : 1.0.0
Release     : 2
Architecture: x86_64
Install Date: (not installed)
```
