### PR TITLE
feat: add release field

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -107,6 +107,7 @@ type Info struct {
 	Arch         string `yaml:"arch,omitempty"`
 	Platform     string `yaml:"platform,omitempty"`
 	Version      string `yaml:"version,omitempty"`
+	Release      string `yaml:"release,omitempty"`
 	Section      string `yaml:"section,omitempty"`
 	Priority     string `yaml:"priority,omitempty"`
 	Maintainer   string `yaml:"maintainer,omitempty"`

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -50,6 +50,9 @@ func (*RPM) Package(info nfpm.Info, w io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("rpmbuild not present in $PATH")
 	}
+	if s := info.Release; s == "" {
+		info.Release = "1"
+	}
 	temps, err := setupTempFiles(info)
 	if err != nil {
 		return err
@@ -219,7 +222,7 @@ func setupTempFiles(info nfpm.Info) (tempFiles, error) {
 		Folder: folder,
 		Source: filepath.Join(root, "SOURCES", folder+".tar.gz"),
 		Spec:   filepath.Join(root, "SPECS", info.Name+".spec"),
-		RPM:    filepath.Join(root, "RPMS", info.Arch, fmt.Sprintf("%s-1.%s.rpm", folder, info.Arch)),
+		RPM:    filepath.Join(root, "RPMS", info.Arch, fmt.Sprintf("%s-%s.%s.rpm", folder, info.Release, info.Arch)),
 	}, nil
 }
 
@@ -313,7 +316,7 @@ const specTemplate = `
 Name: {{ .Info.Name }}
 Summary: {{ first_line .Info.Description }}
 Version: {{ .Info.Version }}
-Release: 1
+Release: {{ .Info.Release }}
 {{- with .Info.License }}
 License: {{ . }}
 {{- end }}

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -24,6 +24,7 @@ func exampleInfo() nfpm.Info {
 		Priority:    "extra",
 		Maintainer:  "Carlos A Becker <pkg@carlosbecker.com>",
 		Version:     "1.0.0",
+		Release:     "1",
 		Section:     "default",
 		Homepage:    "http://carlosbecker.com",
 		Vendor:      "nope",


### PR DESCRIPTION
[2nd attempt, didn't realize there was a test suite issue in rpm that needed to be addressed]

Add support for a setting a 'Release' value other than '1'

```
$ head -5 nfpm.yaml 
name: "csync"
arch: "amd64"
platform: "linux"
version: "1.0.1"
section: "Applications/System"

$ nfpm pkg --target foo.rpm && rpm -qip foo.rpm | head -4 && rm foo.rpm
using rpm packager...
created package: foo.rpm
Name        : csync
Version     : 1.0.1
Release     : 1
Architecture: x86_64

$ ed nfpm.yaml
650
/version
version: "1.0.1"
a
release: "2"
.
wq
663

$ head -5 nfpm.yaml 
name: "csync"
arch: "amd64"
platform: "linux"
version: "1.0.1"
release: "2"

$ nfpm pkg --target foo.rpm && rpm -qip foo.rpm | head -4 && rm foo.rpm
using rpm packager...
created package: foo.rpm
Name        : csync
Version     : 1.0.1
Release     : 2
Architecture: x86_64
```