### PR TITLE
add support for build rpm packages for aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# acceptance does not work with current default trusty
+dist: xenial
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # acceptance does not work with current default trusty
 dist: xenial
-addons:
+addons:     
   apt:
     packages:
     - rpm
@@ -8,6 +8,8 @@ language: go
 go: '1.12.x'
 services:
   - docker
+before_install:
+  - sudo docker run --privileged linuxkit/binfmt:v0.7
 install:
   - make setup
 before_script:

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -49,6 +49,15 @@ func TestSimple(t *testing.T) {
 				Dockerfile: fmt.Sprintf("%s.ppc64le.dockerfile", format),
 			})
 		})
+		t.Run("arm64", func(t *testing.T) {
+			t.Parallel()
+			accept(t, acceptParms{
+				Name:       fmt.Sprintf("simple_%s_arm64", format),
+				Conf:       "simple.arm64.yaml",
+				Format:     format,
+				Dockerfile: fmt.Sprintf("%s.arm64.dockerfile", format),
+			})
+		})
 	}
 }
 

--- a/acceptance/testdata/deb.arm64.dockerfile
+++ b/acceptance/testdata/deb.arm64.dockerfile
@@ -1,0 +1,10 @@
+FROM arm64v8/ubuntu
+ARG package
+COPY ${package} /tmp/foo.deb
+RUN dpkg -i /tmp/foo.deb
+RUN test -e /usr/local/bin/fake
+RUN test -f /etc/foo/whatever.conf
+RUN echo wat >> /etc/foo/whatever.conf
+RUN dpkg -r foo
+RUN test -f /etc/foo/whatever.conf
+RUN test ! -f /usr/local/bin/fake

--- a/acceptance/testdata/rpm.arm64.dockerfile
+++ b/acceptance/testdata/rpm.arm64.dockerfile
@@ -1,0 +1,10 @@
+FROM arm64v8/centos
+ARG package
+COPY ${package} /tmp/foo.rpm
+RUN rpm -ivh /tmp/foo.rpm
+RUN test -e /usr/local/bin/fake
+RUN test -f /etc/foo/whatever.conf
+RUN echo wat >> /etc/foo/whatever.conf
+RUN rpm -e foo
+RUN test -f /etc/foo/whatever.conf.rpmsave
+RUN test ! -f /usr/local/bin/fake

--- a/acceptance/testdata/simple.arm64.yaml
+++ b/acceptance/testdata/simple.arm64.yaml
@@ -1,0 +1,15 @@
+name: "foo"
+arch: "arm64"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+files:
+  ../testdata/fake: "/usr/local/bin/fake"
+config_files:
+  ../testdata/whatever.conf: "/etc/foo/whatever.conf"

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -40,12 +40,17 @@ var archToRPM = map[string]string{
 	"arm64": "aarch64",
 }
 
-// Package writes a new RPM package to the given writer using the given info
-func (*RPM) Package(info nfpm.Info, w io.Writer) error {
+func ensureValidArch(info nfpm.Info) nfpm.Info {
 	arch, ok := archToRPM[info.Arch]
 	if ok {
 		info.Arch = arch
 	}
+	return info
+}
+
+// Package writes a new RPM package to the given writer using the given info
+func (*RPM) Package(info nfpm.Info, w io.Writer) error {
+	info = ensureValidArch(info)
 	info.Version = strings.Replace(info.Version, "-", "_", -1)
 	_, err := exec.LookPath("rpmbuild")
 	if err != nil {

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -37,6 +37,7 @@ type RPM struct{}
 var archToRPM = map[string]string{
 	"amd64": "x86_64",
 	"386":   "i386",
+	"arm64": "aarch64",
 }
 
 // Package writes a new RPM package to the given writer using the given info

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -189,3 +189,13 @@ func TestParseRpmbuildVersionError(t *testing.T) {
 		})
 	}
 }
+
+func TestRPMMultiArch(t *testing.T) {
+	info := exampleInfo()
+
+	for k := range archToRPM {
+		info.Arch = k
+		info = ensureValidArch(info)
+		assert.Equal(t, archToRPM[k], info.Arch)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Christoph Hartmann <chris@lollyrock.com>

Rhel/Fedora use `aarch64` instead of `arm64`.

Reference:
- https://fedoraproject.org/wiki/Architectures/ARM#Introduction