### PR TITLE
Adding Prefix and Group tags

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -109,7 +109,6 @@ type Info struct {
 	Epoch        string `yaml:"epoch,omitempty"`
 	Version      string `yaml:"version,omitempty"`
 	Section      string `yaml:"section,omitempty"`
-	Group        string `yaml:"group,omitempty"`
 	Priority     string `yaml:"priority,omitempty"`
 	Maintainer   string `yaml:"maintainer,omitempty"`
 	Description  string `yaml:"description,omitempty"`
@@ -117,7 +116,7 @@ type Info struct {
 	Homepage     string `yaml:"homepage,omitempty"`
 	License      string `yaml:"license,omitempty"`
 	Bindir       string `yaml:"bindir,omitempty"`
-	Prefix       string `yaml:"prefix,omitempty"`
+	RPM          RPM    `yaml:"rpm,omitempty"`
 }
 
 // Overridables contain the field which are overridable in a package
@@ -132,6 +131,11 @@ type Overridables struct {
 	ConfigFiles  map[string]string `yaml:"config_files,omitempty"`
 	EmptyFolders []string          `yaml:"empty_folders,omitempty"`
 	Scripts      Scripts           `yaml:"scripts,omitempty"`
+}
+
+type RPM struct {
+	Group  string `yaml:"group,omitempty"`
+	Prefix string `yaml:"prefix,omitempty"`
 }
 
 // Scripts contains information about maintainer scripts for packages

--- a/nfpm.go
+++ b/nfpm.go
@@ -109,6 +109,7 @@ type Info struct {
 	Epoch        string `yaml:"epoch,omitempty"`
 	Version      string `yaml:"version,omitempty"`
 	Section      string `yaml:"section,omitempty"`
+	Group        string `yaml:"group,omitempty"`
 	Priority     string `yaml:"priority,omitempty"`
 	Maintainer   string `yaml:"maintainer,omitempty"`
 	Description  string `yaml:"description,omitempty"`
@@ -116,6 +117,7 @@ type Info struct {
 	Homepage     string `yaml:"homepage,omitempty"`
 	License      string `yaml:"license,omitempty"`
 	Bindir       string `yaml:"bindir,omitempty"`
+	Prefix       string `yaml:"prefix,omitempty"`
 }
 
 // Overridables contain the field which are overridable in a package

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -324,7 +324,11 @@ Release: 1
 {{- with .Info.License }}
 License: {{ . }}
 {{- end }}
+{{- with .Info.Group }}
+Group: {{ . }}
+{{- else }}
 Group: Development/Tools
+{{- end }}
 SOURCE0 : %{name}-%{version}.tar.gz
 {{- with .Info.Homepage }}
 URL: {{ . }}
@@ -333,6 +337,9 @@ URL: {{ . }}
 Packager: {{ . }}
 {{- end }}
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+{{- with .Info.Prefix }}
+Prefix: {{ . }}
+{{- end }}
 
 {{ range $index, $element := .Info.Replaces }}
 Obsoletes: {{ . }}

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -66,6 +66,8 @@ func (*RPM) Package(info nfpm.Info, w io.Writer) error {
 		"--verbose",
 		"--define", fmt.Sprintf("_topdir %s", temps.Root),
 		"--define", fmt.Sprintf("_tmppath %s/tmp", temps.Root),
+		"--define", fmt.Sprintf("_rpmfilename %s", filepath.Join(info.Arch, filepath.Base(temps.RPM))),
+		"--define", fmt.Sprintf("_sourcedir %s", filepath.Dir(temps.Source)),
 		"--target", fmt.Sprintf("%s-unknown-%s", info.Arch, info.Platform),
 		"-ba",
 		"SPECS/" + info.Name + ".spec",

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -324,7 +324,7 @@ Release: 1
 {{- with .Info.License }}
 License: {{ . }}
 {{- end }}
-{{- with .Info.Group }}
+{{- with .Info.RPM.Group }}
 Group: {{ . }}
 {{- else }}
 Group: Development/Tools
@@ -337,7 +337,7 @@ URL: {{ . }}
 Packager: {{ . }}
 {{- end }}
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-{{- with .Info.Prefix }}
+{{- with .Info.RPM.Prefix }}
 Prefix: {{ . }}
 {{- end }}
 

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -100,6 +100,8 @@ func TestWithRPMTags(t *testing.T) {
 		Group:  "default",
 		Prefix: "/usr",
 	}
+	var err = Default.Package(info, ioutil.Discard)
+	assert.NoError(t, err)
 }
 
 func TestRPMVersionWithDash(t *testing.T) {

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -104,6 +104,26 @@ func TestWithRPMTags(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRPMTagsSpec(t *testing.T) {
+	var info = exampleInfo()
+	info.RPM = nfpm.RPM{
+		Group:  "default",
+		Prefix: "/usr",
+	}
+
+	vs := rpmbuildVersion{Major: 4, Minor: 15, Patch: 2}
+	golden := "testdata/spec_4.15.x.golden"
+
+	var w bytes.Buffer
+	assert.NoError(t, writeSpec(&w, info, vs))
+	if *update {
+		require.NoError(t, ioutil.WriteFile(golden, w.Bytes(), 0655))
+	}
+	bts, err := ioutil.ReadFile(golden)
+	assert.NoError(t, err)
+	assert.Equal(t, string(bts), w.String())
+}
+
 func TestRPMVersionWithDash(t *testing.T) {
 	info := exampleInfo()
 	info.Version = "1.0.0-beta"

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -94,6 +94,14 @@ func TestRPM(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWithRPMTags(t *testing.T) {
+	var info = exampleInfo()
+	info.RPM = nfpm.RPM{
+		Group:  "default",
+		Prefix: "/usr",
+	}
+}
+
 func TestRPMVersionWithDash(t *testing.T) {
 	info := exampleInfo()
 	info.Version = "1.0.0-beta"

--- a/rpm/testdata/spec_4.15.x.golden
+++ b/rpm/testdata/spec_4.15.x.golden
@@ -1,0 +1,113 @@
+
+%define __spec_install_post %{nil}
+%define debug_package %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define _arch amd64
+%define _bindir /usr/local/bin
+
+Name: foo
+Summary: Foo does things
+Version: 1.0.0
+Release: 1
+License: MIT
+Group: default
+SOURCE0 : %{name}-%{version}.tar.gz
+URL: http://carlosbecker.com
+Packager: Carlos A Becker <pkg@carlosbecker.com>
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+Prefix: /usr
+
+
+Obsoletes: svn
+
+
+
+Conflicts: zsh
+
+
+
+Provides: bzr
+
+
+
+Requires: bash
+
+
+
+
+Recommends: git
+
+
+
+Suggests: bash
+
+
+
+%description
+Foo does things
+
+%prep
+%setup -q
+
+%build
+# Empty section.
+
+%install
+rm -rf %{buildroot}
+mkdir -vp %{buildroot}
+
+mkdir -vp %{buildroot}/var/log/whatever
+
+mkdir -vp %{buildroot}/usr/share/whatever
+
+
+# in builddir
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+
+/usr/local/bin/fake
+
+%{_bindir}/*
+
+/etc/fake/fake.conf
+
+
+%config(noreplace) /etc/fake/fake.conf
+
+
+/var/log/whatever
+
+/usr/share/whatever
+
+
+%pre
+#!/bin/bash
+
+echo "Preinstall" > /dev/null
+
+
+%post
+#!/bin/bash
+
+echo "Postinstall" > /dev/null
+
+
+%preun
+#!/bin/bash
+
+echo "Preremove" > /dev/null
+
+
+%postun
+#!/bin/bash
+
+echo "Postremove" > /dev/null
+
+
+%changelog
+# noop


### PR DESCRIPTION
Prefix and Group tags added for RPMs only since those tags do not exist for deb packages. 

Also defined some macros for rpmbuild to make nfpm less dependent on the build environment.