### PR TITLE
feat: Add option for RPM compression type

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -115,6 +115,22 @@ func TestMinDeb(t *testing.T) {
 	}
 }
 
+func TestRPMCompression(t *testing.T) {
+	compressFormats := []string{"gzip", "xz", "lzma"}
+	for _, format := range compressFormats {
+		format := format
+		t.Run(format, func(t *testing.T) {
+			t.Parallel()
+			accept(t, acceptParms{
+				Name:       fmt.Sprintf("%s_compression_rpm", format),
+				Conf:       fmt.Sprintf("%s.compression.yaml", format),
+				Format:     "rpm",
+				Dockerfile: fmt.Sprintf("%s.rpm.compression.dockerfile", format),
+			})
+		})
+	}
+}
+
 type acceptParms struct {
 	Name       string
 	Conf       string

--- a/acceptance/testdata/gzip.compression.yaml
+++ b/acceptance/testdata/gzip.compression.yaml
@@ -1,0 +1,17 @@
+name: "foo"
+arch: "amd64"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+files:
+  ../testdata/fake: "/usr/local/bin/fake"
+config_files:
+  ../testdata/whatever.conf: "/etc/foo/whatever.conf"
+rpm:
+  compression: "gzip"

--- a/acceptance/testdata/gzip.rpm.compression.dockerfile
+++ b/acceptance/testdata/gzip.rpm.compression.dockerfile
@@ -1,0 +1,11 @@
+FROM fedora
+ARG package
+COPY ${package} /tmp/foo.rpm
+RUN test "gzip" = "$(rpm -qp --qf '%{PAYLOADCOMPRESSOR}' /tmp/foo.rpm)"
+RUN rpm -ivh /tmp/foo.rpm
+RUN test -e /usr/local/bin/fake
+RUN test -f /etc/foo/whatever.conf
+RUN echo wat >> /etc/foo/whatever.conf
+RUN rpm -e foo
+RUN test -f /etc/foo/whatever.conf.rpmsave
+RUN test ! -f /usr/local/bin/fake

--- a/acceptance/testdata/lzma.compression.yaml
+++ b/acceptance/testdata/lzma.compression.yaml
@@ -1,0 +1,17 @@
+name: "foo"
+arch: "amd64"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+files:
+  ../testdata/fake: "/usr/local/bin/fake"
+config_files:
+  ../testdata/whatever.conf: "/etc/foo/whatever.conf"
+rpm:
+  compression: "lzma"

--- a/acceptance/testdata/lzma.rpm.compression.dockerfile
+++ b/acceptance/testdata/lzma.rpm.compression.dockerfile
@@ -1,0 +1,11 @@
+FROM fedora
+ARG package
+COPY ${package} /tmp/foo.rpm
+RUN test "lzma" = "$(rpm -qp --qf '%{PAYLOADCOMPRESSOR}' /tmp/foo.rpm)"
+RUN rpm -ivh /tmp/foo.rpm
+RUN test -e /usr/local/bin/fake
+RUN test -f /etc/foo/whatever.conf
+RUN echo wat >> /etc/foo/whatever.conf
+RUN rpm -e foo
+RUN test -f /etc/foo/whatever.conf.rpmsave
+RUN test ! -f /usr/local/bin/fake

--- a/acceptance/testdata/xz.compression.yaml
+++ b/acceptance/testdata/xz.compression.yaml
@@ -1,0 +1,17 @@
+name: "foo"
+arch: "amd64"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+files:
+  ../testdata/fake: "/usr/local/bin/fake"
+config_files:
+  ../testdata/whatever.conf: "/etc/foo/whatever.conf"
+rpm:
+  compression: "xz"

--- a/acceptance/testdata/xz.rpm.compression.dockerfile
+++ b/acceptance/testdata/xz.rpm.compression.dockerfile
@@ -1,0 +1,11 @@
+FROM fedora
+ARG package
+COPY ${package} /tmp/foo.rpm
+RUN test "xz" = "$(rpm -qp --qf '%{PAYLOADCOMPRESSOR}' /tmp/foo.rpm)"
+RUN rpm -ivh /tmp/foo.rpm
+RUN test -e /usr/local/bin/fake
+RUN test -f /etc/foo/whatever.conf
+RUN echo wat >> /etc/foo/whatever.conf
+RUN rpm -e foo
+RUN test -f /etc/foo/whatever.conf.rpmsave
+RUN test ! -f /usr/local/bin/fake

--- a/nfpm.go
+++ b/nfpm.go
@@ -134,8 +134,9 @@ type Overridables struct {
 }
 
 type RPM struct {
-	Group  string `yaml:"group,omitempty"`
-	Prefix string `yaml:"prefix,omitempty"`
+	Group       string `yaml:"group,omitempty"`
+	Prefix      string `yaml:"prefix,omitempty"`
+	Compression string `yaml:"compression,omitempty"`
 }
 
 // Scripts contains information about maintainer scripts for packages

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -319,6 +319,18 @@ const specTemplate = `
 %define __os_install_post %{_dbpath}/brp-compress
 %define _arch {{ .Info.Arch }}
 %define _bindir {{ .Info.Bindir }}
+{{- if eq .Info.RPM.Compression "gzip"}}
+%define _source_payload w9.gzdio
+%define _binary_payload w9.gzdio
+{{- end}}
+{{- if eq .Info.RPM.Compression "xz"}}
+%define _source_payload w6.xzdio
+%define _binary_payload w6.xzdio
+{{- end}}
+{{- if eq .Info.RPM.Compression "lzma"}}
+%define _source_payload w6.lzdio
+%define _binary_payload w6.lzdio
+{{- end}}
 
 Name: {{ .Info.Name }}
 Summary: {{ first_line .Info.Description }}


### PR DESCRIPTION
Allows you to choose between gzip, xz, and lzma as the RPM compression type.

See #62