### PR TITLE
fix: Typo in rpm.go comments

### DIFF
--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -26,7 +26,7 @@ func init() {
 	nfpm.Register("rpm", Default)
 }
 
-// Default deb packager
+// Default RPM packager
 // nolint: gochecknoglobals
 var Default = &RPM{}
 


### PR DESCRIPTION
Fixes a small typo in source comments.