### PR TITLE
fix: parse the version as a semver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SOURCE_FILES?=./...
 TEST_PATTERN?=.
 TEST_OPTIONS?=
+TEST_TIMEOUT?=5m
 
 export PATH := ./bin:$(PATH)
 export GO111MODULE := on
@@ -18,7 +19,7 @@ pull_test_imgs:
 .PHONY: pull_test_imgs
 
 test: pull_test_imgs
-	go test $(TEST_OPTIONS) -v -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.out $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=5m
+	go test $(TEST_OPTIONS) -v -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.out $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=$(TEST_TIMEOUT)
 .PHONY: test
 
 cover: test

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -86,6 +86,22 @@ func TestComplex(t *testing.T) {
 	}
 }
 
+func TestEnvVarVersion(t *testing.T) {
+	for _, format := range formats {
+		format := format
+		t.Run(fmt.Sprintf("amd64-%s", format), func(t *testing.T) {
+			t.Parallel()
+			os.Setenv("SEMVER", "v1.0.0-0.1.b1+git.abcdefgh")
+			accept(t, acceptParms{
+				Name:       fmt.Sprintf("env-var-version_%s", format),
+				Conf:       "env-var-version.yaml",
+				Format:     format,
+				Dockerfile: fmt.Sprintf("%s.env-var-version.dockerfile", format),
+			})
+		})
+	}
+}
+
 func TestComplexOverrides(t *testing.T) {
 	for _, format := range formats {
 		format := format

--- a/acceptance/testdata/deb.env-var-version.dockerfile
+++ b/acceptance/testdata/deb.env-var-version.dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu
+ARG package
+COPY ${package} /tmp/foo.deb
+ENV EXPECTVER=" Version: 1.0.0~0.1.b1+git.abcdefgh"
+RUN dpkg --info /tmp/foo.deb | grep "Version" > found
+RUN export FOUND_VER="$(cat found)" && \
+    echo "Expected: '${EXPECTVER}' :: Found: '${FOUND_VER}'" && \
+    test "${FOUND_VER}" = "${EXPECTVER}"

--- a/acceptance/testdata/env-var-version.yaml
+++ b/acceptance/testdata/env-var-version.yaml
@@ -1,0 +1,32 @@
+name: "foo"
+arch: "amd64"
+platform: "linux"
+version: "${SEMVER}"
+maintainer: "Foo Bar"
+depends:
+  - bash
+provides:
+  - fake
+replaces:
+  - foo
+suggests:
+  - zsh
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+files:
+  ../testdata/fake: "/usr/local/bin/fake"
+  ./testdata/folder/**/*: "/usr/share/whatever/folder/"
+config_files:
+  ../testdata/whatever.conf: "/etc/foo/whatever.conf"
+empty_folders:
+  - /var/log/whatever
+  - /usr/share/foo
+scripts:
+  preinstall: ./testdata/scripts/preinstall.sh
+  postinstall: ./testdata/scripts/postinstall.sh
+  preremove: ./testdata/scripts/preremove.sh
+  postremove: ./testdata/scripts/postremove.sh

--- a/acceptance/testdata/rpm.env-var-version.dockerfile
+++ b/acceptance/testdata/rpm.env-var-version.dockerfile
@@ -1,0 +1,13 @@
+FROM fedora
+ARG package
+COPY ${package} /tmp/foo.rpm
+ENV EXPECTVER="Version : 1.0.0" \
+    EXPECTREL="Release : 0.1.b1"
+RUN rpm -qpi /tmp/foo.rpm | sed -e 's/ \+/ /g' | grep "Version" > found.ver
+RUN rpm -qpi /tmp/foo.rpm | sed -e 's/ \+/ /g' | grep "Release" > found.rel
+RUN export FOUND_VER="$(cat found.ver)" && \
+    echo "Expected: ${EXPECTVER}' :: Found: '${FOUND_VER}'" && \
+    test "${FOUND_VER}" = "${EXPECTVER}"
+RUN export FOUND_REL="$(cat found.rel)" && \
+    echo "Expected: '${EXPECTREL}' :: Found: '${FOUND_REL}'" && \
+    test "${FOUND_REL}" = "${EXPECTREL}"

--- a/acceptance/testdata/simple.yaml
+++ b/acceptance/testdata/simple.yaml
@@ -2,6 +2,7 @@ name: "foo"
 arch: "amd64"
 platform: "linux"
 version: "v1.2.3"
+release: "simple"
 maintainer: "Foo Bar"
 description: |
   Foo bar

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -335,11 +335,9 @@ func conffiles(info nfpm.Info) []byte {
 const controlTemplate = `
 {{- /* Mandatory fields */ -}}
 Package: {{.Info.Name}}
-{{- if .Info.Epoch}}
-Version: {{ .Info.Epoch }}:{{.Info.Version}}
-{{- else }}
-Version: {{.Info.Version}}
-{{- end }}
+Version: {{ if .Info.Epoch}}{{ .Info.Epoch }}:{{ end }}{{.Info.Version}}
+         {{- if .Info.Release}}~{{ .Info.Release }}{{- end }}
+         {{- if .Info.Deb.VersionMetadata}}+{{ .Info.Deb.VersionMetadata }}{{- end }}
 Section: {{.Info.Section}}
 Priority: {{.Info.Priority}}
 Architecture: {{.Info.Arch}}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/goreleaser/nfpm
 go 1.13
 
 require (
+	github.com/Masterminds/semver/v3 v3.0.1
 	github.com/alecthomas/kingpin v2.2.6+incompatible
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.0.1 h1:2kKm5lb7dKVrt5TYUiAavE6oFc1cFT0057UVGT+JqLk=
+github.com/Masterminds/semver/v3 v3.0.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/alecthomas/kingpin v2.2.6+incompatible h1:5svnBTFgJjZvGKyYBtMB0+m5wvrbUHiqye8wRJMlnYI=
 github.com/alecthomas/kingpin v2.2.6+incompatible/go.mod h1:59OFYbFVLKQKq+mqrL6Rw5bR0c3ACQaawgXx0QYndlE=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/google/rpmpack"
 	"github.com/goreleaser/nfpm"
@@ -85,9 +84,6 @@ func buildRPMMeta(info nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		suggests,
 		conflicts rpmpack.Relations
 	)
-	vInfo := strings.SplitN(info.Version, "-", 2)
-	vInfo = append(vInfo, info.RPM.Release)
-
 	if provides, err = toRelation(info.Provides); err != nil {
 		return nil, err
 	}
@@ -107,8 +103,8 @@ func buildRPMMeta(info nfpm.Info) (*rpmpack.RPMMetaData, error) {
 	return &rpmpack.RPMMetaData{
 		Name:        info.Name,
 		Description: info.Description,
-		Version:     vInfo[0],
-		Release:     vInfo[1],
+		Version:     info.Version,
+		Release:     info.Release,
 		Arch:        info.Arch,
 		OS:          info.Platform,
 		Licence:     info.License,


### PR DESCRIPTION
* Split the parsed version into `Version` & `Release`
* Properly build the deb `Version` using `~` to seperate `Version` & `Release`
* No longer have a custom version parser for rpm

Closes: #50 