### PR TITLE
chore: add stricter linting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/bash
+FILES=$(git diff --staged --diff-filter=AM --no-renames --name-only)
+export TEST_PATTERN=TestSimple
+make fmt lint test && git add $FILES

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ nfpm.yaml
 .DS_Store
 bin
 coverage.out
-nfpm
+/nfpm

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,35 @@
+linters:
+  enable-all: true
+  disable:
+    - godox
+    - wsl
+linters-settings:
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 30
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: github.com/goreleaser/nfpm
+  govet:
+    check-shadowing: true
+  errcheck:
+    ignore: ^Close.*,fmt:.*,github.com/pkg/errors:^Wrap.*,os:^Setenv$
+  lll:
+    line-length: 200
+  golint:
+    min-confidence: .8
+  nakedret:
+    max-func-lines: 0
+  gocritic:
+    enabled-tags:
+      - style
+      - performance
+issues:
+  exclude-rules:
+    - text: "G104" # gosec G104 is caught by errcheck
+      linters:
+        - gosec

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ export GOPROXY := https://proxy.golang.org,https://gocenter.io,direct
 setup:
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
 	go mod tidy
+	git config core.hooksPath .githooks
 .PHONY: setup
 
 
@@ -31,7 +32,7 @@ fmt:
 .PHONY: fmt
 
 lint: check
-	./bin/golangci-lint run --disable wsl --disable godox --enable-all ./...
+	./bin/golangci-lint run --exclude-use-default=false --fix -v
 .PHONY: check
 
 ci: build lint test
@@ -40,6 +41,12 @@ ci: build lint test
 build:
 	go build -o nfpm ./cmd/nfpm/main.go
 .PHONY: build
+
+deps:
+	go get -u
+	go mod tidy
+	go mod verify
+.PHONY: deps
 
 todo:
 	@grep \

--- a/acceptance/placeholder.go
+++ b/acceptance/placeholder.go
@@ -1,3 +1,4 @@
+// Package acceptance contains acceptance tests
 package acceptance
 
 // This file only exists to make go test happy.

--- a/cmd/nfpm/main.go
+++ b/cmd/nfpm/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/alecthomas/kingpin"
+
 	"github.com/goreleaser/nfpm"
 	_ "github.com/goreleaser/nfpm/deb"
 	_ "github.com/goreleaser/nfpm/rpm"

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -9,16 +9,17 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/goreleaser/nfpm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/goreleaser/nfpm"
 )
 
 // nolint: gochecknoglobals
 var update = flag.Bool("update", false, "update .golden files")
 
-func exampleInfo() nfpm.Info {
-	return nfpm.WithDefaults(nfpm.Info{
+func exampleInfo() *nfpm.Info {
+	return nfpm.WithDefaults(&nfpm.Info{
 		Name:        "foo",
 		Arch:        "amd64",
 		Description: "Foo does things",
@@ -119,7 +120,7 @@ func TestScripts(t *testing.T) {
 func TestNoJoinsControl(t *testing.T) {
 	var w bytes.Buffer
 	assert.NoError(t, writeControl(&w, controlData{
-		Info: nfpm.WithDefaults(nfpm.Info{
+		Info: nfpm.WithDefaults(&nfpm.Info{
 			Name:        "foo",
 			Arch:        "amd64",
 			Description: "Foo does things",
@@ -153,7 +154,7 @@ func TestNoJoinsControl(t *testing.T) {
 
 func TestDebFileDoesNotExist(t *testing.T) {
 	var err = Default.Package(
-		nfpm.WithDefaults(nfpm.Info{
+		nfpm.WithDefaults(&nfpm.Info{
 			Name:        "foo",
 			Arch:        "amd64",
 			Description: "Foo does things",
@@ -182,7 +183,7 @@ func TestDebFileDoesNotExist(t *testing.T) {
 
 func TestDebNoFiles(t *testing.T) {
 	var err = Default.Package(
-		nfpm.WithDefaults(nfpm.Info{
+		nfpm.WithDefaults(&nfpm.Info{
 			Name:        "foo",
 			Arch:        "amd64",
 			Description: "Foo does things",
@@ -204,12 +205,12 @@ func TestDebNoFiles(t *testing.T) {
 }
 
 func TestDebNoInfo(t *testing.T) {
-	var err = Default.Package(nfpm.WithDefaults(nfpm.Info{}), ioutil.Discard)
+	var err = Default.Package(nfpm.WithDefaults(&nfpm.Info{}), ioutil.Discard)
 	assert.NoError(t, err)
 }
 
 func TestConffiles(t *testing.T) {
-	out := conffiles(nfpm.Info{
+	out := conffiles(&nfpm.Info{
 		Overridables: nfpm.Overridables{
 			ConfigFiles: map[string]string{
 				"fake": "/etc/fake",
@@ -236,7 +237,7 @@ func TestPathsToCreate(t *testing.T) {
 func TestMinimalFields(t *testing.T) {
 	var w bytes.Buffer
 	assert.NoError(t, writeControl(&w, controlData{
-		Info: nfpm.WithDefaults(nfpm.Info{
+		Info: nfpm.WithDefaults(&nfpm.Info{
 			Name:        "minimal",
 			Arch:        "arm64",
 			Description: "Minimal does nothing",
@@ -257,7 +258,7 @@ func TestMinimalFields(t *testing.T) {
 func TestDebEpoch(t *testing.T) {
 	var w bytes.Buffer
 	assert.NoError(t, writeControl(&w, controlData{
-		Info: nfpm.WithDefaults(nfpm.Info{
+		Info: nfpm.WithDefaults(&nfpm.Info{
 			Name:        "withepoch",
 			Arch:        "arm64",
 			Description: "Has an epoch added to it's version",
@@ -279,7 +280,7 @@ func TestDebEpoch(t *testing.T) {
 func TestDebRules(t *testing.T) {
 	var w bytes.Buffer
 	assert.NoError(t, writeControl(&w, controlData{
-		Info: nfpm.WithDefaults(nfpm.Info{
+		Info: nfpm.WithDefaults(&nfpm.Info{
 			Name:        "lala",
 			Arch:        "arm64",
 			Description: "Has rules script",

--- a/glob/glob.go
+++ b/glob/glob.go
@@ -23,7 +23,7 @@ func longestCommonPrefix(strs []string) string {
 	return lcp
 }
 
-func strlcp(a string, b string) string {
+func strlcp(a, b string) string {
 	var min int
 	if len(a) > len(b) {
 		min = len(b)

--- a/nfpm.go
+++ b/nfpm.go
@@ -94,7 +94,7 @@ func (c *Config) Get(format string) (info *Info, err error) {
 	info = &Info{}
 	// make a deep copy of info
 	if err = mergo.Merge(info, c.Info); err != nil {
-		return nil, errors.Wrap(err, "Failed to merge config into info")
+		return nil, errors.Wrap(err, "failed to merge config into info")
 	}
 	override, ok := c.Overrides[format]
 	if !ok {
@@ -102,7 +102,7 @@ func (c *Config) Get(format string) (info *Info, err error) {
 		return info, nil
 	}
 	if err = mergo.Merge(&info.Overridables, override, mergo.WithOverride); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge overrides into info")
 	}
 	return info, nil
 }

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -34,7 +34,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestDefaultsOnEmptyInfo(t *testing.T) {
-	info := Info{
+	info := &Info{
 		Version: "2.4.1",
 	}
 	info = WithDefaults(info)
@@ -44,7 +44,7 @@ func TestDefaultsOnEmptyInfo(t *testing.T) {
 }
 
 func TestDefaults(t *testing.T) {
-	info := Info{
+	info := &Info{
 		Bindir:      "/usr/bin",
 		Platform:    "darwin",
 		Version:     "2.4.1",
@@ -55,7 +55,7 @@ func TestDefaults(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	require.NoError(t, Validate(Info{
+	require.NoError(t, Validate(&Info{
 		Name:    "as",
 		Arch:    "asd",
 		Version: "1.2.3",
@@ -65,7 +65,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 	}))
-	require.NoError(t, Validate(Info{
+	require.NoError(t, Validate(&Info{
 		Name:    "as",
 		Arch:    "asd",
 		Version: "1.2.3",
@@ -96,7 +96,7 @@ func TestValidateError(t *testing.T) {
 		err := err
 		info := info
 		t.Run(err, func(t *testing.T) {
-			require.EqualError(t, Validate(info), err)
+			require.EqualError(t, Validate(&info), err)
 		})
 	}
 }
@@ -146,11 +146,11 @@ func TestOverrides(t *testing.T) {
 	// no overrides
 	info, err := config.Get("doesnotexist")
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(config.Info, info))
+	assert.True(t, reflect.DeepEqual(&config.Info, info))
 }
 
 type fakePackager struct{}
 
-func (*fakePackager) Package(info Info, w io.Writer) error {
+func (*fakePackager) Package(info *Info, w io.Writer) error {
 	return nil
 }

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/goreleaser/nfpm"
 	"github.com/sassoftware/go-rpmutils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/goreleaser/nfpm"
 )
 
 const (
@@ -18,8 +19,8 @@ const (
 	tagPostun = 0x0402 // 1026
 )
 
-func exampleInfo() nfpm.Info {
-	return nfpm.WithDefaults(nfpm.Info{
+func exampleInfo() *nfpm.Info {
+	return nfpm.WithDefaults(&nfpm.Info{
 		Name:        "foo",
 		Arch:        "amd64",
 		Description: "Foo does things",
@@ -98,7 +99,8 @@ func TestRPMScripts(t *testing.T) {
 	f, err := ioutil.TempFile(".", fmt.Sprintf("%s-%s-*.rpm", info.Name, info.Version))
 	defer func() {
 		_ = f.Close()
-		os.Remove(f.Name())
+		err = os.Remove(f.Name())
+		assert.NoError(t, err)
 	}()
 	assert.NoError(t, err)
 	err = Default.Package(info, f)


### PR DESCRIPTION
These are the errors that were found and fixed

```
./bin/golangci-lint run --exclude-use-default=false --fix -v
INFO [config_reader] Config search paths: [./ /opt/projects/go/nfpm /opt/projects/go /opt/projects /opt /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 36 linters: [bodyclose deadcode depguard dogsled dupl errcheck funlen gochecknoglobals gochecknoinits gocognit goconst gocritic gocyclo gofmt goimports golint gosec gosimple govet ineffassign interfacer lll maligned misspell nakedret prealloc scopelint staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace] 
INFO [loader] Go packages loading at mode 575 (deps|exports_file|files|types_sizes|compiled_files|name|imports) took 339.823287ms 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 4.478827ms 
INFO [runner/max_same_issues] 12/15 issues with text "hugeParam: info is heavy (568 bytes); consider passing it by pointer" were hidden, use --max-same-issues 
INFO [runner] Issues before processing: 54, after processing: 14 
INFO [runner] Processors filtering stat (out/in): path_prettifier: 54/54, exclude: 54/54, diff: 26/26, max_from_linter: 14/14, skip_files: 54/54, autogenerated_exclude: 54/54, max_per_file_from_linter: 26/26, source_code: 14/14, cgo: 54/54, identifier_marker: 54/54, exclude-rules: 52/54, nolint: 26/52, uniq_by_line: 26/26, max_same_issues: 14/26, filename_unadjuster: 54/54, skip_dirs: 54/54, path_shortener: 14/14 
INFO [runner] processing took 11.387623ms with stages: nolint: 8.313388ms, identifier_marker: 1.988598ms, path_prettifier: 220.409µs, exclude-rules: 209.314µs, source_code: 193.796µs, autogenerated_exclude: 161.701µs, skip_dirs: 127.282µs, max_same_issues: 94.505µs, cgo: 25.195µs, uniq_by_line: 16.985µs, filename_unadjuster: 14.952µs, max_from_linter: 8.428µs, path_shortener: 6.739µs, max_per_file_from_linter: 4.724µs, exclude: 644ns, diff: 522ns, skip_files: 441ns 
INFO [runner] linters took 1.032264664s with stages: goanalysis_metalinter: 646.924839ms, unused: 373.810741ms 
INFO fixer took 0s with no stages                 
nfpm.go:56:8: shadow: declaration of "err" shadows declaration at line 41 (govet)
	if v, err := semver.NewVersion(config.Info.Version); err == nil {
	      ^
acceptance/placeholder.go:1:1: ST1000: at least one file in a package should have a package comment (stylecheck)
package acceptance
^
glob/glob.go:26:1: paramTypeCombine: func(a string, b string) string could be replaced with func(a, b string) string (gocritic)
func strlcp(a string, b string) string {
^
deb/deb.go:48:21: hugeParam: info is heavy (568 bytes); consider passing it by pointer (gocritic)
func (*Deb) Package(info nfpm.Info, deb io.Writer) (err error) {
                    ^
deb/deb.go:91:22: hugeParam: info is heavy (568 bytes); consider passing it by pointer (gocritic)
func createDataTarGz(info nfpm.Info) (dataTarGz, md5sums []byte, instSize int64, err error) {
                     ^
deb/deb.go:121:29: hugeParam: info is heavy (568 bytes); consider passing it by pointer (gocritic)
func createFilesInsideTarGz(info nfpm.Info, out *tar.Writer, created map[string]bool) (bytes.Buffer, int64, error) {
                            ^
deb/deb.go:245:58: hugeParam: header is heavy (216 bytes); consider passing it by pointer (gocritic)
func newItemInsideTarGz(out *tar.Writer, content []byte, header tar.Header) error {
                                                         ^
deb/deb.go:383:32: hugeParam: data is heavy (576 bytes); consider passing it by pointer (gocritic)
func writeControl(w io.Writer, data controlData) error {
                               ^
deb/deb.go:266:1: paramTypeCombine: func(out *tar.Writer, path string, dest string) error could be replaced with func(out *tar.Writer, path, dest string) error (gocritic)
func newScriptInsideTarGz(out *tar.Writer, path string, dest string) error {
^
rpm/rpm.go:182:2: builtinShadow: shadowing of predeclared identifier: copy (gocritic)
	copy := func(files map[string]string, config bool) error {
	^
rpm/rpm_test.go:102:12: Error return value of `os.Remove` is not checked (errcheck)
		os.Remove(f.Name())
		         ^
acceptance/acceptance_test.go:94:13: Error return value of `os.Setenv` is not checked (errcheck)
			os.Setenv("SEMVER", "v1.0.0-0.1.b1+git.abcdefgh")
			         ^
nfpm.go:64:2: naked return in func `Parse` with 24 lines of code (nakedret)
	return
	^
nfpm.go:105:2: naked return in func `Get` with 15 lines of code (nakedret)
	return
	^
INFO File cache stats: 18 entries of total size 80.1KiB 
INFO Memory: 15 samples, avg is 100.5MB, max is 136.5MB 
INFO Execution took 1.390817233s
```