### PR TITLE
fix: remove rpm.Prefix and rpm.Release

### DIFF
--- a/acceptance/testdata/release.rpm.yaml
+++ b/acceptance/testdata/release.rpm.yaml
@@ -3,6 +3,7 @@ arch: "amd64"
 platform: "linux"
 version: "v1.2.3"
 maintainer: "Foo Bar"
+release: "4"
 description: |
   Foo bar
     Multiple lines
@@ -13,5 +14,3 @@ files:
   ../testdata/fake: "/usr/local/bin/fake"
 config_files:
   ../testdata/whatever.conf: "/etc/foo/whatever.conf"
-rpm:
-  release: "4"

--- a/nfpm.go
+++ b/nfpm.go
@@ -155,7 +155,6 @@ type Overridables struct {
 // RPM is custom configs that are only available on RPM packages
 type RPM struct {
 	Group       string `yaml:"group,omitempty"`
-	Prefix      string `yaml:"prefix,omitempty"`
 	Compression string `yaml:"compression,omitempty"`
 	Release     string `yaml:"release,omitempty"`
 }

--- a/nfpm.go
+++ b/nfpm.go
@@ -46,13 +46,9 @@ func Parse(in io.Reader) (config Config, err error) {
 		return
 	}
 
-	// preserver backwards compatibility
-	if config.Info.RPM.Release != "" && config.Info.Release == "" {
-		config.Info.Release = os.ExpandEnv(config.Info.RPM.Release)
-	}
 	config.Info.Release = os.ExpandEnv(config.Info.Release)
-
 	config.Info.Version = os.ExpandEnv(config.Info.Version)
+
 	// parse the version as a semver so we can properly split the parts and support proper ordering for both rpm and deb
 	var v *semver.Version
 	if v, err = semver.NewVersion(config.Info.Version); err == nil {
@@ -156,7 +152,6 @@ type Overridables struct {
 type RPM struct {
 	Group       string `yaml:"group,omitempty"`
 	Compression string `yaml:"compression,omitempty"`
-	Release     string `yaml:"release,omitempty"`
 }
 
 // Deb is custom configs that are only available on deb packages

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -102,8 +102,7 @@ func TestWithRPMTags(t *testing.T) {
 	var info = exampleInfo()
 	info.Release = "3"
 	info.RPM = nfpm.RPM{
-		Group:  "default",
-		Prefix: "/usr",
+		Group: "default",
 	}
 	assert.NoError(t, Default.Package(info, f))
 


### PR DESCRIPTION
As far as I understand `Prefix` is just to avoid repeating a folder when referencing files.

so, it seems like it didn't make much sense before, and makes less sense now.

IMHO we can just remove it.

`Release` is already a field on the `root` struct, so I think we can remove it as well.