### PR TITLE
fix: Correct typo in eaxmple config

### DIFF
--- a/cmd/nfpm/main.go
+++ b/cmd/nfpm/main.go
@@ -110,7 +110,7 @@ description: |
   FooBar is the great foo and bar software.
     And this can be in multiple lines!
 vendor: "FooBarCorp"
-homepage: "http://eaxmple.com"
+homepage: "http://example.com"
 license: "MIT"
 bindir: "/usr/local/bin"
 files:


### PR DESCRIPTION
just fixing a small typo that stuck out to me as I set this up!