### PR TITLE
fix(rpm): with defaults: fix version and pre-release

### DIFF
--- a/cmd/nfpm/main.go
+++ b/cmd/nfpm/main.go
@@ -66,9 +66,13 @@ func doPackage(path, target string) error {
 	if err != nil {
 		return err
 	}
+
+	info = nfpm.WithDefaults(info)
+
 	if err = nfpm.Validate(info); err != nil {
 		return err
 	}
+
 	fmt.Printf("using %s packager...\n", format)
 	pkg, err := nfpm.Get(format)
 	if err != nil {
@@ -79,7 +83,7 @@ func doPackage(path, target string) error {
 	if err != nil {
 		return err
 	}
-	return pkg.Package(nfpm.WithDefaults(info), f)
+	return pkg.Package(info, f)
 }
 
 const example = `# nfpm example config file

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b h1:+gCnWOZV8Z/8jehJ2CdqB47Z3S+SREmQcuXkRFLNsiI=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/nfpm.go
+++ b/nfpm.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
@@ -49,17 +48,7 @@ func Parse(in io.Reader) (config Config, err error) {
 	config.Info.Release = os.ExpandEnv(config.Info.Release)
 	config.Info.Version = os.ExpandEnv(config.Info.Version)
 
-	// parse the version as a semver so we can properly split the parts and support proper ordering for both rpm and deb
-	var v *semver.Version
-	if v, err = semver.NewVersion(config.Info.Version); err == nil {
-		config.Info.Version = fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch())
-		if config.Info.Release == "" {
-			config.Info.Release = v.Prerelease()
-		}
-		config.Info.Deb.VersionMetadata = v.Metadata()
-	}
-	err = config.Validate()
-	return config, err
+	return config, config.Validate()
 }
 
 // ParseFile decodes YAML data from a file path into a configuration struct
@@ -201,6 +190,16 @@ func WithDefaults(info *Info) *Info {
 	if info.Description == "" {
 		info.Description = "no description given"
 	}
-	info.Version = strings.TrimPrefix(info.Version, "v")
+
+	// parse the version as a semver so we can properly split the parts
+	// and support proper ordering for both rpm and deb
+	if v, err := semver.NewVersion(info.Version); err == nil {
+		info.Version = fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch())
+		if info.Release == "" {
+			// maybe we should concat the previous info.Release with v.Prerelease?
+			info.Release = v.Prerelease()
+		}
+		info.Deb.VersionMetadata = v.Metadata()
+	}
 	return info
 }

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -33,14 +33,27 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, pkgr, got)
 }
 
-func TestDefaultsOnEmptyInfo(t *testing.T) {
+func TestDefaultsVersion(t *testing.T) {
 	info := &Info{
-		Version: "2.4.1",
+		Version: "v2.4.1-beta3",
 	}
 	info = WithDefaults(info)
 	assert.NotEmpty(t, info.Bindir)
 	assert.NotEmpty(t, info.Platform)
 	assert.Equal(t, "2.4.1", info.Version)
+	assert.Equal(t, "beta3", info.Release)
+}
+
+func TestDefaultsVersionWithRelease(t *testing.T) {
+	info := &Info{
+		Version: "v2.4.1-beta3",
+		Release: "4",
+	}
+	info = WithDefaults(info)
+	assert.NotEmpty(t, info.Bindir)
+	assert.NotEmpty(t, info.Platform)
+	assert.Equal(t, "2.4.1", info.Version)
+	assert.Equal(t, "4", info.Release)
 }
 
 func TestDefaults(t *testing.T) {

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -107,7 +107,7 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		Name:        info.Name,
 		Summary:     strings.Split(info.Description, "\n")[0],
 		Description: info.Description,
-		Version:     info.Version,
+		Version:     strings.Replace(info.Version, "-", "_", -1),
 		Release:     defaultTo(info.Release, "1"),
 		Arch:        info.Arch,
 		OS:          info.Platform,

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -107,7 +107,7 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		Name:        info.Name,
 		Summary:     strings.Split(info.Description, "\n")[0],
 		Description: info.Description,
-		Version:     strings.Replace(info.Version, "-", "_", -1),
+		Version:     info.Version,
 		Release:     defaultTo(info.Release, "1"),
 		Arch:        info.Arch,
 		OS:          info.Platform,

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	tagVersion     = 0x03e9 // 1001
 	tagRelease     = 0x03ea // 1002
 	tagSummary     = 0x03ec // 1004
 	tagDescription = 0x03ed // 1005
@@ -90,6 +91,10 @@ func TestRPM(t *testing.T) {
 	rpm, err := rpmutils.ReadRpm(file)
 	assert.NoError(t, err)
 
+	version, err := rpm.Header.GetString(tagVersion)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.0.0", version)
+
 	release, err := rpm.Header.GetString(tagRelease)
 	assert.NoError(t, err)
 	assert.Equal(t, "1", release)
@@ -117,6 +122,7 @@ func TestWithRPMTags(t *testing.T) {
 
 	var info = exampleInfo()
 	info.Release = "3"
+	info.Version = "v1.2.0-beta1"
 	info.RPM = nfpm.RPM{
 		Group: "default",
 	}
@@ -128,6 +134,10 @@ func TestWithRPMTags(t *testing.T) {
 
 	rpm, err := rpmutils.ReadRpm(file)
 	assert.NoError(t, err)
+
+	version, err := rpm.Header.GetString(tagVersion)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.0_beta1", version)
 
 	release, err := rpm.Header.GetString(tagRelease)
 	assert.NoError(t, err)
@@ -144,13 +154,6 @@ func TestWithRPMTags(t *testing.T) {
 	description, err := rpm.Header.GetString(tagDescription)
 	assert.NoError(t, err)
 	assert.Equal(t, info.Description, description)
-}
-
-func TestRPMVersionWithDash(t *testing.T) {
-	info := exampleInfo()
-	info.Version = "1.0.0-beta"
-	var err = Default.Package(info, ioutil.Discard)
-	assert.NoError(t, err)
 }
 
 func TestRPMScripts(t *testing.T) {

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -122,7 +122,6 @@ func TestWithRPMTags(t *testing.T) {
 
 	var info = exampleInfo()
 	info.Release = "3"
-	info.Version = "v1.2.0-beta1"
 	info.RPM = nfpm.RPM{
 		Group: "default",
 	}
@@ -137,7 +136,7 @@ func TestWithRPMTags(t *testing.T) {
 
 	version, err := rpm.Header.GetString(tagVersion)
 	assert.NoError(t, err)
-	assert.Equal(t, "1.2.0_beta1", version)
+	assert.Equal(t, "1.0.0", version)
 
 	release, err := rpm.Header.GetString(tagRelease)
 	assert.NoError(t, err)


### PR DESCRIPTION
refs https://github.com/goreleaser/goreleaser/issues/1229#issuecomment-549659537

~~not sure this is the right way to go, I'm sleepy and will check again tomorrow :)~~

fixed in a more proper way, moved the version parse to `WithDefaults`.