### PR TITLE
fix(#103): ensure the package is not included in itself 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ A good way of making sure everything is all right is running the test suite:
 $ make test
 ```
 
+If on the ARM tests you are seeing `standard_init_linux.go:211: exec user process caused "exec format error"`:
+
+```console
+$sudo docker run --rm --privileged hypriot/qemu-register
+```
+
 ## Test your change
 
 You can create a branch for your changes and try to build from the source as you go:

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -194,6 +194,7 @@ func accept(t *testing.T, params acceptParms) {
 
 	f, err := os.Create(target)
 	require.NoError(t, err)
+	info.Target = target
 	require.NoError(t, pkg.Package(nfpm.WithDefaults(info), f))
 	//nolint:gosec
 	cmd := exec.Command(

--- a/cmd/nfpm/main.go
+++ b/cmd/nfpm/main.go
@@ -83,6 +83,8 @@ func doPackage(path, target string) error {
 	if err != nil {
 		return err
 	}
+
+	info.Target = target
 	return pkg.Package(info, f)
 }
 

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -131,6 +131,9 @@ func createFilesInsideTarGz(info *nfpm.Info, out *tar.Writer, created map[string
 				return md5buf, 0, err
 			}
 			for src, dst := range globbed {
+				if strings.Contains(src, info.Target) {
+					continue
+				}
 				if err := createTree(out, dst, created); err != nil {
 					return md5buf, 0, err
 				}

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -131,7 +131,7 @@ func createFilesInsideTarGz(info *nfpm.Info, out *tar.Writer, created map[string
 				return md5buf, 0, err
 			}
 			for src, dst := range globbed {
-				if strings.Contains(src, info.Target) {
+				if strings.HasSuffix(src, info.Target) {
 					continue
 				}
 				if err := createTree(out, dst, created); err != nil {

--- a/nfpm.go
+++ b/nfpm.go
@@ -119,6 +119,7 @@ type Info struct {
 	Homepage     string `yaml:"homepage,omitempty"`
 	License      string `yaml:"license,omitempty"`
 	Bindir       string `yaml:"bindir,omitempty"`
+	Target       string `yaml:"-"`
 }
 
 // Overridables contain the field which are overridable in a package

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -200,7 +200,7 @@ func createFilesInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) error {
 				return err
 			}
 			for src, dst := range globbed {
-				if strings.Contains(src, info.Target) {
+				if strings.HasSuffix(src, info.Target) {
 					fmt.Println("skipping", src)
 					continue
 				}

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -3,6 +3,7 @@
 package rpm
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -199,6 +200,10 @@ func createFilesInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) error {
 				return err
 			}
 			for src, dst := range globbed {
+				if strings.Contains(src, info.Target) {
+					fmt.Println("skipping", src)
+					continue
+				}
 				err := copyToRPM(rpm, src, dst, config)
 				if err != nil {
 					return err


### PR DESCRIPTION
ensure the package is not included in itself when using globs to match all files

Closes #103 