### PR TITLE
fix: updated architectures for arm5 and arm6

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -31,7 +31,8 @@ func init() {
 var archToDebian = map[string]string{
 	"386":     "i386",
 	"arm":     "armhf",
-	"arm6":    "armel",
+	"arm5":    "armel",
+	"arm6":    "armhf",
 	"arm7":    "armhf",
 	"mipsle":  "mipsel",
 	"ppc64le": "ppc64el",


### PR DESCRIPTION
I updated your ARM architecture as ARM6 is actually armhf and ARM5 is armel (I think) as per this page: https://github.com/golang/go/wiki/GoArm
