### PR TITLE
fix: make epoch work again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/rpmpack v0.0.0-20191123225850-3293c964e1e6
+	github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0
 	github.com/imdario/mergo v0.3.8
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-zglob v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/rpmpack v0.0.0-20191123225850-3293c964e1e6 h1:iTi+hixsnUSMvXFp3vr+84Paw9+jyDikfmMcZlTMoTI=
-github.com/google/rpmpack v0.0.0-20191123225850-3293c964e1e6/go.mod h1:RaTPr0KUf2K7fnZYLNDrr8rxAamWs3iNywJLtQ2AzBg=
+github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0 h1:BW6OvS3kpT5UEPbCZ+KyX/OB4Ks9/MNMhWjqPPkZxsE=
+github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0/go.mod h1:RaTPr0KUf2K7fnZYLNDrr8rxAamWs3iNywJLtQ2AzBg=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -81,13 +82,17 @@ func (*RPM) Package(info *nfpm.Info, w io.Writer) error {
 
 func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 	var (
-		err error
+		err   error
+		epoch uint64
 		provides,
 		depends,
 		replaces,
 		suggests,
 		conflicts rpmpack.Relations
 	)
+	if epoch, err = strconv.ParseUint(defaultTo(info.Epoch, "0"), 10, 32); err != nil {
+		return nil, err
+	}
 	if provides, err = toRelation(info.Provides); err != nil {
 		return nil, err
 	}
@@ -115,6 +120,7 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		Description: info.Description,
 		Version:     info.Version,
 		Release:     defaultTo(info.Release, "1"),
+		Epoch:       uint32(epoch),
 		Arch:        info.Arch,
 		OS:          info.Platform,
 		Licence:     info.License,

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -171,6 +171,24 @@ func TestWithRPMTags(t *testing.T) {
 	assert.Equal(t, info.Description, description)
 }
 
+func TestWithInvalidEpoch(t *testing.T) {
+	f, err := ioutil.TempFile("", "test.rpm")
+	defer func() {
+		_ = f.Close()
+		err = os.Remove(f.Name())
+		assert.NoError(t, err)
+	}()
+
+	var info = exampleInfo()
+	info.Release = "3"
+	info.Epoch = "-1"
+	info.RPM = nfpm.RPM{
+		Group: "default",
+	}
+	info.Description = "first line\nsecond line\nthird line"
+	assert.Error(t, Default.Package(info, f))
+}
+
 func TestRPMScripts(t *testing.T) {
 	info := exampleInfo()
 	f, err := ioutil.TempFile(".", fmt.Sprintf("%s-%s-*.rpm", info.Name, info.Version))

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -15,6 +15,7 @@ import (
 const (
 	tagVersion     = 0x03e9 // 1001
 	tagRelease     = 0x03ea // 1002
+	tagEpoch       = 0x03eb // 1003
 	tagSummary     = 0x03ec // 1004
 	tagDescription = 0x03ed // 1005
 	tagGroup       = 0x03f8 // 1016
@@ -99,6 +100,13 @@ func TestRPM(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "1", release)
 
+	epoch, err := rpm.Header.Get(tagEpoch)
+	assert.NoError(t, err)
+	epochUint32, ok := epoch.([]uint32)
+	assert.Len(t, epochUint32, 1)
+	assert.True(t, ok)
+	assert.Equal(t, uint32(0), epochUint32[0])
+
 	group, err := rpm.Header.GetString(tagGroup)
 	assert.NoError(t, err)
 	assert.Equal(t, "Development/Tools", group)
@@ -122,6 +130,7 @@ func TestWithRPMTags(t *testing.T) {
 
 	var info = exampleInfo()
 	info.Release = "3"
+	info.Epoch = "42"
 	info.RPM = nfpm.RPM{
 		Group: "default",
 	}
@@ -141,6 +150,13 @@ func TestWithRPMTags(t *testing.T) {
 	release, err := rpm.Header.GetString(tagRelease)
 	assert.NoError(t, err)
 	assert.Equal(t, "3", release)
+
+	epoch, err := rpm.Header.Get(tagEpoch)
+	assert.NoError(t, err)
+	epochUint32, ok := epoch.([]uint32)
+	assert.Len(t, epochUint32, 1)
+	assert.True(t, ok)
+	assert.Equal(t, uint32(42), epochUint32[0])
 
 	group, err := rpm.Header.GetString(tagGroup)
 	assert.NoError(t, err)


### PR DESCRIPTION
Epoch is already merged in google/rpmpack (https://github.com/google/rpmpack/commit/aa36bfddb3a0c725e19c73e75d76fea48882c399)