### PR TITLE
fix: Handle multiline input for the Debian description field

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -380,7 +380,7 @@ Conflicts: {{join .}}
 Homepage: {{.Info.Homepage}}
 {{- end }}
 {{- /* Mandatory fields */}}
-Description: {{.Info.Description}}
+Description: {{multiline .Info.Description}}
 `
 
 type controlData struct {
@@ -393,6 +393,10 @@ func writeControl(w io.Writer, data controlData) error {
 	tmpl.Funcs(template.FuncMap{
 		"join": func(strs []string) string {
 			return strings.Trim(strings.Join(strs, ", "), " ")
+		},
+		"multiline": func(strs string) string {
+			ret := strings.ReplaceAll(strs, "\n", "\n  ")
+			return strings.Trim(ret, " \n")
 		},
 	})
 	return template.Must(tmpl.Parse(controlTemplate)).Execute(w, data)

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -305,3 +305,24 @@ func TestDebRules(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, string(bts), w.String())
 }
+
+func TestMultilineFields(t *testing.T) {
+	var w bytes.Buffer
+	assert.NoError(t, writeControl(&w, controlData{
+		Info: nfpm.WithDefaults(&nfpm.Info{
+			Name:        "multiline",
+			Arch:        "riscv64",
+			Description: "This field is a\nmultiline field\nthat should work.",
+			Priority:    "extra",
+			Version:     "1.0.0",
+			Section:     "default",
+		}),
+	}))
+	var golden = "testdata/multiline.golden"
+	if *update {
+		require.NoError(t, ioutil.WriteFile(golden, w.Bytes(), 0655))
+	}
+	bts, err := ioutil.ReadFile(golden) //nolint:gosec
+	assert.NoError(t, err)
+	assert.Equal(t, string(bts), w.String())
+}

--- a/deb/testdata/multiline.golden
+++ b/deb/testdata/multiline.golden
@@ -1,0 +1,9 @@
+Package: multiline
+Version: 1.0.0
+Section: default
+Priority: extra
+Architecture: riscv64
+Installed-Size: 0
+Description: This field is a
+  multiline field
+  that should work.


### PR DESCRIPTION
Hi There

The description field in the DEB control file supports multiline/verbatim input. It is done by indenting the lines by two spaces. Before this patch, the control file was broken if a user wanted to supply a multiline description.

Blank lines by using a full-stop-character are not implemented as it requires to convert the whole block to a 1-level intended block instead of the verbatim 2-level intended block.

Ref: [debian-policy](https://www.debian.org/doc/debian-policy/ch-controlfields.html#description)