### PR TITLE
Fix glob patterns for files and config_files

### DIFF
--- a/glob/glob.go
+++ b/glob/glob.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mattn/go-zglob"
 	"github.com/pkg/errors"
@@ -51,8 +52,8 @@ func Glob(glob, dst string) (map[string]string, error) {
 	}
 	files := make(map[string]string)
 	prefix := longestCommonPrefix(matches)
-	// the prefix may not be a complete path, in that case use the parent directory
-	if _, err := os.Stat(prefix); os.IsNotExist(err) {
+	// the prefix may not be a complete path or may use glob patterns, in that case use the parent directory
+	if _, err := os.Stat(prefix); os.IsNotExist(err) || strings.ContainsAny(glob, "*") {
 		prefix = filepath.Dir(prefix)
 	}
 	for _, src := range matches {

--- a/glob/glob_test.go
+++ b/glob/glob_test.go
@@ -44,6 +44,11 @@ func TestGlob(t *testing.T) {
 	assert.Equal(t, "/foo/bar/dir_b/test_b.txt", files["testdata/dir_a/dir_b/test_b.txt"])
 	assert.Equal(t, "/foo/bar/dir_c/test_c.txt", files["testdata/dir_a/dir_c/test_c.txt"])
 
+	singleFile, err := Glob("testdata/dir_a/dir_b/*", "/foo/bar")
+	assert.NoError(t, err)
+	assert.Len(t, singleFile, 1)
+	assert.Equal(t, "/foo/bar/test_b.txt", singleFile["testdata/dir_a/dir_b/test_b.txt"])
+
 	nilvalue, err := Glob("does/not/exist", "/foo/bar")
 	assert.EqualError(t, err, "does/not/exist: file does not exist")
 	assert.Nil(t, nilvalue)


### PR DESCRIPTION
We use nfpm for creating Debian packages. In our nfpm.yaml file we make use of glob patterns for `files`. In the following example we copy all artifacts from `a` to `/tmp/a` and from `b` to `/tmp/b`:
```
files:
  "./a/**/*": "/tmp/a/"
  "./b/**/*": "/tmp/b/"
```

nfpm does not work as expected when the directories `a` or `b` only contain a single file (e.g. ./a/test.txt). In this case nfpm creates a deb package that contains the content of ./a/test.txt as a file at the path /tmp/a. Instead we expect ./a/test.txt to be packaged as file at the path /tmp/a/test.txt.

For our use cases this fix is kind of important and the only work-around right now is to make sure that there are always at least two files below a and b.