### PR TITLE
fix rpm recommends

### DIFF
--- a/acceptance/testdata/complex.yaml
+++ b/acceptance/testdata/complex.yaml
@@ -7,6 +7,8 @@ depends:
 - bash
 provides:
 - fake
+recommends:
+- fish
 replaces:
 - foo
 suggests:

--- a/acceptance/testdata/rpm.complex.dockerfile
+++ b/acceptance/testdata/rpm.complex.dockerfile
@@ -1,6 +1,8 @@
 FROM fedora
 ARG package
 COPY ${package} /tmp/foo.rpm
+RUN test "$(rpm -qp --recommends /tmp/foo.rpm)" = "fish"
+RUN test "$(rpm -qp --suggests /tmp/foo.rpm)" = "zsh"
 RUN rpm -ivh /tmp/foo.rpm
 RUN test -e /usr/local/bin/fake
 RUN test -f /etc/foo/whatever.conf

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -85,6 +85,7 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		epoch uint64
 		provides,
 		depends,
+		recommends,
 		replaces,
 		suggests,
 		conflicts rpmpack.Relations
@@ -96,6 +97,9 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		return nil, err
 	}
 	if depends, err = toRelation(info.Depends); err != nil {
+		return nil, err
+	}
+	if recommends, err = toRelation(info.Recommends); err != nil {
 		return nil, err
 	}
 	if replaces, err = toRelation(info.Replaces); err != nil {
@@ -128,6 +132,7 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		Packager:    info.Maintainer,
 		Group:       defaultTo(info.RPM.Group, "Development/Tools"),
 		Provides:    provides,
+		Recommends:  recommends,
 		Requires:    depends,
 		Obsoletes:   replaces,
 		Suggests:    suggests,

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -79,6 +79,7 @@ func (*RPM) Package(info *nfpm.Info, w io.Writer) error {
 	return nil
 }
 
+//nolint:funlen
 func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 	var (
 		err   error


### PR DESCRIPTION
Fixes goreleaser/goreleaser/issues/1636

`recommends` was not being included in the rpmpack struct so including that field in the nfpm config was ineffective. fixed that so that rpms correctly include the recommended packages.

After applying this patch and rebuilding goreleaser:
```
$ sudo dnf repoquery --recommends ./my-app.rpm
Last metadata expiration check: 2:10:04 ago on Wed 01 Jul 2020 10:28:08 AM EDT.
< the recommended dependency >

$ sudo dnf install ./my-app.rpm               
Last metadata expiration check: 2:10:11 ago on Wed 01 Jul 2020 10:28:08 AM EDT.
Dependencies resolved.
===
[...]
Installing weak dependencies:
 < the recommended dependency >
```