### PR TITLE
Feature(RPM): Allow platform independet packages by translating arch "all" to "noarch" for RPM packages

### DIFF
--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -31,6 +31,7 @@ type RPM struct{}
 
 // nolint: gochecknoglobals
 var archToRPM = map[string]string{
+	"all":   "noarch",
 	"amd64": "x86_64",
 	"386":   "i386",
 	"arm64": "aarch64",


### PR DESCRIPTION
If I'm not mistaken, there is currently no way to build architecture independent DEB and RPM packages with the same configuration file. This change enables users to do this by specifying `arch: all` by translating `all` to `noarch` for RPMs, which is the equivalent architecture there.

PS: I couldn't locally run the the CI pipeline because I created this pull request on a machine without access to docker, but it should be okay for such a minor change.