### PR TITLE
WIP: feat: Use conventional file names by default

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -44,6 +44,19 @@ var Default = &Deb{}
 // Deb is a deb packager implementation.
 type Deb struct{}
 
+// ConventionalFileName returns a file name according
+// to the conventions for debian packages. See:
+// https://manpages.debian.org/buster/dpkg-dev/dpkg-name.1.en.html
+func (*Deb) ConventionalFileName(info *nfpm.Info) string {
+	arch, ok := archToDebian[info.Arch]
+	if !ok {
+		arch = info.Arch
+	}
+
+	// package_version_architecture.package-type
+	return fmt.Sprintf("%s_%s_%s.deb", info.Name, info.Version, arch)
+}
+
 // Package writes a new deb package to the given writer using the given info.
 func (*Deb) Package(info *nfpm.Info, deb io.Writer) (err error) {
 	arch, ok := archToDebian[info.Arch]

--- a/nfpm.go
+++ b/nfpm.go
@@ -81,6 +81,7 @@ func ParseFile(path string) (config Config, err error) {
 // Packager represents any packager implementation.
 type Packager interface {
 	Package(info *Info, w io.Writer) error
+	ConventionalFileName(info *Info) string
 }
 
 // Config contains the top level configuration for packages.

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -213,6 +213,10 @@ func TestListFilesToCopy(t *testing.T) {
 
 type fakePackager struct{}
 
+func (*fakePackager) ConventionalFileName(info *Info) string {
+	return ""
+}
+
 func (*fakePackager) Package(info *Info, w io.Writer) error {
 	return nil
 }

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -44,6 +44,15 @@ func ensureValidArch(info *nfpm.Info) *nfpm.Info {
 	return info
 }
 
+// ConventionalFileName returns a file name according
+// to the conventions for RPM packages. See:
+// http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
+func (*RPM) ConventionalFileName(info *nfpm.Info) string {
+	info = ensureValidArch(info)
+	// name-version-release.architecture.rpm
+	return fmt.Sprintf("%s_%s.%s.rpm", info.Name, info.Version, info.Arch)
+}
+
 // Package writes a new RPM package to the given writer using the given info.
 func (*RPM) Package(info *nfpm.Info, w io.Writer) error {
 	var (


### PR DESCRIPTION
This pull request changes the behaviour of the `--target` CLI option to produce conventional file for the respective packages by default. Conventional file names are for example [package_version_architecture.package-type](https://manpages.debian.org/buster/dpkg-dev/dpkg-name.1.en.html) for Debian packages and [name-version-release.architecture.rpm](http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html) for RPMs. Consider the following cases:
* **`--target` is blank or omitted:** Create a package with a conventional file name in current directory
* **`--target` is a directory:** Create a package with a conventional file name in the directory
* **`--target` is a file name:** Use this file name

### Why?
Because at the moment, `nfpm` allows users to omit `--target` and uses the very weird default `/tmp/foo.deb` in this case. A default value should cover the most common use cases and creating the file `/tmp/foo.deb` would be a very weird use case and is just plain wrong for RPM files.

### At the moment, there are a few issues:
* I don't know if adding a new function to the Packager interface is a bit too drastic, but currently, I cannot move the function to `nfpm.go` (where I initially put it) because it needs access to the architecture translation and it has to be ensured that every future architecture provides such a name.
* I also changed a bit at the end of `doPackage()` because the success message now has to be printed there. At the same time, I changed the behaviour to remove the empty package file if packaging fails. Is it okay to also include that in this pull request? 
* I could not run the tests because I don't have access to docker on this machine