### PR TITLE
docs: update contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ Prerequisites:
 
 * `make`
 * [Go 1.14+](https://golang.org/doc/install)
-* rpm (`apt-get install rpm`/`brew install rpm`)
 
 Clone `nfpm` from source:
 
@@ -35,7 +34,7 @@ $ make test
 If on the ARM tests you are seeing `standard_init_linux.go:211: exec user process caused "exec format error"`:
 
 ```console
-$sudo docker run --rm --privileged hypriot/qemu-register
+$ sudo docker run --rm --privileged hypriot/qemu-register
 ```
 
 ## Test your change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ conduct](/CODE_OF_CONDUCT.md).
 Prerequisites:
 
 * `make`
-* [Go 1.11+](https://golang.org/doc/install)
+* [Go 1.14+](https://golang.org/doc/install)
 * rpm (`apt-get install rpm`/`brew install rpm`)
 
 Clone `nfpm` from source:

--- a/www/docs/install.md
+++ b/www/docs/install.md
@@ -68,13 +68,13 @@ $ cd nfpm
 **Get the dependencies:**
 
 ```console
-$ go get ./...
+$ go mod download
 ```
 
 **Build:**
 
 ```console
-$ go build -o nfpm .
+$ go build -o nfpm cmd/nfpm/main.go
 ```
 
 **Verify it works:**


### PR DESCRIPTION
we don't really test on go 1.11, so better don't assume it works.

changed docs to instruct the usage of latest version

also upgraded other deprecated instructions.


closes https://github.com/goreleaser/nfpm/issues/127