### PR TITLE
fix: Improve changelog formatting.

### DIFF
--- a/acceptance/testdata/rpm.changelog.dockerfile
+++ b/acceptance/testdata/rpm.changelog.dockerfile
@@ -3,11 +3,11 @@ ARG package
 COPY ${package} /tmp/foo.rpm
 RUN rpm -ivh /tmp/foo.rpm
 RUN rpm -qp /tmp/foo.rpm --changelog | grep "Carlos A Becker <pkg@carlosbecker.com>"
-RUN rpm -qp /tmp/foo.rpm --changelog | grep "note 1"
-RUN rpm -qp /tmp/foo.rpm --changelog | grep "note 2"
-RUN rpm -qp /tmp/foo.rpm --changelog | grep "note 3"
+RUN rpm -qp /tmp/foo.rpm --changelog | grep -E "^- note 1$"
+RUN rpm -qp /tmp/foo.rpm --changelog | grep -E "^- note 2$"
+RUN rpm -qp /tmp/foo.rpm --changelog | grep -E "^- note 3$"
 RUN rpm -q foo --changelog | grep "Carlos A Becker <pkg@carlosbecker.com>"
-RUN rpm -q foo --changelog | grep "note 1"
-RUN rpm -q foo --changelog | grep "note 2"
-RUN rpm -q foo --changelog | grep "note 3"
+RUN rpm -q foo --changelog | grep -E "^- note 1$"
+RUN rpm -q foo --changelog | grep -E "^- note 2$"
+RUN rpm -q foo --changelog | grep -E "^- note 3$"
 RUN rpm -e foo

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -252,7 +252,7 @@ func createChangelog(info *nfpm.Info) (chglogTarGz []byte, err error) {
 }
 
 func formatChangelog(info *nfpm.Info) (string, error) {
-	pkgChglog, err := info.GetChangeLog()
+	changelog, err := info.GetChangeLog()
 	if err != nil {
 		return "", err
 	}
@@ -262,12 +262,12 @@ func formatChangelog(info *nfpm.Info) (string, error) {
 		return "", err
 	}
 
-	chglogData, err := chglog.FormatChangelog(pkgChglog, tpl)
+	formattedChangelog, err := chglog.FormatChangelog(changelog, tpl)
 	if err != nil {
 		return "", err
 	}
 
-	return chglogData, nil
+	return strings.TrimSpace(formattedChangelog) + "\n", nil
 }
 
 func createControl(instSize int64, md5sums []byte, info *nfpm.Info) (controlTarGz []byte, err error) {

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -531,5 +531,5 @@ func readAndFormatAsDebChangelog(changelogFileName, packageName string) (string,
 		return "", err
 	}
 
-	return debChangelog, nil
+	return strings.TrimSpace(debChangelog) + "\n", nil
 }

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -29,11 +29,11 @@ const (
 	tagChangelogText = 1082
 
 	changelogNotesTemplate = `
-	{{- range .Changes }}{{$note := splitList "\n" .Note}}
-	- {{ first $note }}
-	{{- range $i,$n := (rest $note) }}{{- if ne (trim $n) ""}}
-	{{$n}}{{end}}
-	{{- end}}{{- end}}`
+{{- range .Changes }}{{$note := splitList "\n" .Note}}
+- {{ first $note }}
+{{- range $i,$n := (rest $note) }}{{- if ne (trim $n) ""}}
+{{$n}}{{end}}
+{{- end}}{{- end}}`
 )
 
 // nolint: gochecknoinits


### PR DESCRIPTION
This pull request fixes the following formatting problems in changelogs:
* RPM: Unintended changenote indentation after first note
* DEB: Remove unnecessary leading and trailing newlines

Also, the acceptance test are now more strict when checking the RPM changelog formatting.