### PR TITLE
fix: Reflect (pre)release in conventional file names.

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -55,8 +55,16 @@ func (*Deb) ConventionalFileName(info *nfpm.Info) string {
 		arch = info.Arch
 	}
 
+	version := info.Version
+	if info.Release != "" {
+		version += "-" + info.Release
+	}
+	if info.Prerelease != "" {
+		version += "~" + info.Prerelease
+	}
+
 	// package_version_architecture.package-type
-	return fmt.Sprintf("%s_%s_%s.deb", info.Name, info.Version, arch)
+	return fmt.Sprintf("%s_%s_%s.deb", info.Name, version, arch)
 }
 
 // Package writes a new deb package to the given writer using the given info.

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -396,16 +396,16 @@ func TestDEBConventionalFileName(t *testing.T) {
 		Version    string
 		Release    string
 		Prerelease string
-		expected   string
+		Expected   string
 	}{
 		{Version: "1.2.3", Release: "", Prerelease: "",
-			expected: fmt.Sprintf("%s_1.2.3_%s.deb", info.Name, info.Arch)},
+			Expected: fmt.Sprintf("%s_1.2.3_%s.deb", info.Name, info.Arch)},
 		{Version: "1.2.3", Release: "4", Prerelease: "",
-			expected: fmt.Sprintf("%s_1.2.3-4_%s.deb", info.Name, info.Arch)},
+			Expected: fmt.Sprintf("%s_1.2.3-4_%s.deb", info.Name, info.Arch)},
 		{Version: "1.2.3", Release: "4", Prerelease: "5",
-			expected: fmt.Sprintf("%s_1.2.3-4~5_%s.deb", info.Name, info.Arch)},
+			Expected: fmt.Sprintf("%s_1.2.3-4~5_%s.deb", info.Name, info.Arch)},
 		{Version: "1.2.3", Release: "", Prerelease: "5",
-			expected: fmt.Sprintf("%s_1.2.3~5_%s.deb", info.Name, info.Arch)},
+			Expected: fmt.Sprintf("%s_1.2.3~5_%s.deb", info.Name, info.Arch)},
 	}
 
 	for _, testCase := range testCases {
@@ -413,7 +413,7 @@ func TestDEBConventionalFileName(t *testing.T) {
 		info.Release = testCase.Release
 		info.Prerelease = testCase.Prerelease
 
-		assert.Equal(t, testCase.expected, Default.ConventionalFileName(info))
+		assert.Equal(t, testCase.Expected, Default.ConventionalFileName(info))
 	}
 }
 

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -386,6 +386,37 @@ func TestMultilineFields(t *testing.T) {
 	assert.Equal(t, string(bts), w.String())
 }
 
+func TestDEBConventionalFileName(t *testing.T) {
+	info := &nfpm.Info{
+		Name: "testpkg",
+		Arch: "all",
+	}
+
+	testCases := []struct {
+		Version    string
+		Release    string
+		Prerelease string
+		expected   string
+	}{
+		{Version: "1.2.3", Release: "", Prerelease: "",
+			expected: fmt.Sprintf("%s_1.2.3_%s.deb", info.Name, info.Arch)},
+		{Version: "1.2.3", Release: "4", Prerelease: "",
+			expected: fmt.Sprintf("%s_1.2.3-4_%s.deb", info.Name, info.Arch)},
+		{Version: "1.2.3", Release: "4", Prerelease: "5",
+			expected: fmt.Sprintf("%s_1.2.3-4~5_%s.deb", info.Name, info.Arch)},
+		{Version: "1.2.3", Release: "", Prerelease: "5",
+			expected: fmt.Sprintf("%s_1.2.3~5_%s.deb", info.Name, info.Arch)},
+	}
+
+	for _, testCase := range testCases {
+		info.Version = testCase.Version
+		info.Release = testCase.Release
+		info.Prerelease = testCase.Prerelease
+
+		assert.Equal(t, testCase.expected, Default.ConventionalFileName(info))
+	}
+}
+
 func TestDebChangelogControl(t *testing.T) {
 	info := &nfpm.Info{
 		Name:        "changelog-test",

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -69,8 +69,17 @@ func ensureValidArch(info *nfpm.Info) *nfpm.Info {
 // http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
 func (*RPM) ConventionalFileName(info *nfpm.Info) string {
 	info = ensureValidArch(info)
+
+	version := info.Version
+	if info.Release != "" {
+		version += "-" + info.Release
+	}
+	if info.Prerelease != "" {
+		version += "~" + info.Prerelease
+	}
+
 	// name-version-release.architecture.rpm
-	return fmt.Sprintf("%s-%s.%s.rpm", info.Name, info.Version, info.Arch)
+	return fmt.Sprintf("%s-%s.%s.rpm", info.Name, version, info.Arch)
 }
 
 // Package writes a new RPM package to the given writer using the given info.

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -302,6 +302,37 @@ func TestRPMMultiArch(t *testing.T) {
 	}
 }
 
+func TestRPMConventionalFileName(t *testing.T) {
+	info := &nfpm.Info{
+		Name: "testpkg",
+		Arch: "noarch",
+	}
+
+	testCases := []struct {
+		Version    string
+		Release    string
+		Prerelease string
+		expected   string
+	}{
+		{Version: "1.2.3", Release: "", Prerelease: "",
+			expected: fmt.Sprintf("%s-1.2.3.%s.rpm", info.Name, info.Arch)},
+		{Version: "1.2.3", Release: "4", Prerelease: "",
+			expected: fmt.Sprintf("%s-1.2.3-4.%s.rpm", info.Name, info.Arch)},
+		{Version: "1.2.3", Release: "4", Prerelease: "5",
+			expected: fmt.Sprintf("%s-1.2.3-4~5.%s.rpm", info.Name, info.Arch)},
+		{Version: "1.2.3", Release: "", Prerelease: "5",
+			expected: fmt.Sprintf("%s-1.2.3~5.%s.rpm", info.Name, info.Arch)},
+	}
+
+	for _, testCase := range testCases {
+		info.Version = testCase.Version
+		info.Release = testCase.Release
+		info.Prerelease = testCase.Prerelease
+
+		assert.Equal(t, testCase.expected, Default.ConventionalFileName(info))
+	}
+}
+
 func TestRPMChangelog(t *testing.T) {
 	info := exampleInfo()
 	info.Changelog = "../testdata/changelog.yaml"

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -312,16 +312,16 @@ func TestRPMConventionalFileName(t *testing.T) {
 		Version    string
 		Release    string
 		Prerelease string
-		expected   string
+		Expected   string
 	}{
 		{Version: "1.2.3", Release: "", Prerelease: "",
-			expected: fmt.Sprintf("%s-1.2.3.%s.rpm", info.Name, info.Arch)},
+			Expected: fmt.Sprintf("%s-1.2.3.%s.rpm", info.Name, info.Arch)},
 		{Version: "1.2.3", Release: "4", Prerelease: "",
-			expected: fmt.Sprintf("%s-1.2.3-4.%s.rpm", info.Name, info.Arch)},
+			Expected: fmt.Sprintf("%s-1.2.3-4.%s.rpm", info.Name, info.Arch)},
 		{Version: "1.2.3", Release: "4", Prerelease: "5",
-			expected: fmt.Sprintf("%s-1.2.3-4~5.%s.rpm", info.Name, info.Arch)},
+			Expected: fmt.Sprintf("%s-1.2.3-4~5.%s.rpm", info.Name, info.Arch)},
 		{Version: "1.2.3", Release: "", Prerelease: "5",
-			expected: fmt.Sprintf("%s-1.2.3~5.%s.rpm", info.Name, info.Arch)},
+			Expected: fmt.Sprintf("%s-1.2.3~5.%s.rpm", info.Name, info.Arch)},
 	}
 
 	for _, testCase := range testCases {
@@ -329,7 +329,7 @@ func TestRPMConventionalFileName(t *testing.T) {
 		info.Release = testCase.Release
 		info.Prerelease = testCase.Prerelease
 
-		assert.Equal(t, testCase.expected, Default.ConventionalFileName(info))
+		assert.Equal(t, testCase.Expected, Default.ConventionalFileName(info))
 	}
 }
 


### PR DESCRIPTION
This pull request adds release and pre-release information to the conventional file names. I did not include this earlier because I thought that `info.Version` already contained the full version information available. This results in the following possibilities:
* `1.2.3` if `info.Release` and `info.Prerelease` are empty
* `1.2.3-4` if `info.Release` is set to `4` and `info.Prerelease` is empty
* `1.2.3-4~5` if `info.Release` is set to `4` and `info.Prerelease` is set to `5
* `1.2.3~5` if `info.Release` is empty and `info.Prerelease` is set to `5`

This only affects the default output file names.