### PR TITLE
feat: Add support for DEB triggers.

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -196,6 +196,18 @@ func TestChangelog(t *testing.T) {
 	}
 }
 
+func TestDebTriggers(t *testing.T) {
+	t.Run("triggers-deb", func(t *testing.T) {
+		t.Parallel()
+		accept(t, acceptParms{
+			Name:       "triggers-deb",
+			Conf:       "triggers.yaml",
+			Format:     "deb",
+			Dockerfile: "deb.triggers.dockerfile",
+		})
+	})
+}
+
 type acceptParms struct {
 	Name       string
 	Conf       string

--- a/acceptance/testdata/deb.triggers.dockerfile
+++ b/acceptance/testdata/deb.triggers.dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu
+ARG package
+COPY ${package} /tmp/foo.deb
+RUN dpkg -i /tmp/foo.deb
+
+# simulate another package that activates the trigger
+RUN dpkg-trigger --by-package foo manual-trigger
+RUN dpkg --triggers-only foo
+
+RUN test -f /tmp/trigger-proof
+
+RUN dpkg -r foo

--- a/acceptance/testdata/scripts/postinstall_trigger.sh
+++ b/acceptance/testdata/scripts/postinstall_trigger.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ "$1" = "triggered" ] && [ "$2" = "manual-trigger" ]; then
+    echo "Ok" > /tmp/trigger-proof
+fi

--- a/acceptance/testdata/triggers.yaml
+++ b/acceptance/testdata/triggers.yaml
@@ -1,0 +1,15 @@
+name: "foo"
+arch: "amd64"
+platform: "linux"
+version: "v1.2.3-beta"
+maintainer: "Foo Bar"
+vendor: "foobar"
+license: "MIT"
+files:
+  ../testdata/fake: "/usr/local/bin/fake"
+scripts:
+  postinstall: ./testdata/scripts/postinstall_trigger.sh
+deb:
+  triggers:
+    interest:
+      - manual-trigger

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -498,7 +498,7 @@ func TestDebTriggers(t *testing.T) {
 	info := &nfpm.Info{
 		Name:        "no-triggers-test",
 		Arch:        "amd64",
-		Description: "This package has explicitly no triggers.",
+		Description: "This package has multiple triggers.",
 		Version:     "1.0.0",
 		Overridables: nfpm.Overridables{
 			Deb: nfpm.Deb{

--- a/nfpm.go
+++ b/nfpm.go
@@ -167,8 +167,21 @@ type RPM struct {
 
 // Deb is custom configs that are only available on deb packages.
 type Deb struct {
-	Scripts         DebScripts `yaml:"scripts,omitempty"`
-	VersionMetadata string     `yaml:"metadata,omitempty"`
+	Scripts         DebScripts  `yaml:"scripts,omitempty"`
+	Triggers        DebTriggers `yaml:"triggers,omitempty"`
+	VersionMetadata string      `yaml:"metadata,omitempty"`
+}
+
+// DebTriggers contains triggers only available for deb packages.
+// https://wiki.debian.org/DpkgTriggers
+// https://man7.org/linux/man-pages/man5/deb-triggers.5.html
+type DebTriggers struct {
+	Interest        []string `yaml:"interest,omitempty"`
+	InterestAwait   []string `yaml:"interest_await,omitempty"`
+	InterestNoAwait []string `yaml:"interest_noawait,omitempty"`
+	Activate        []string `yaml:"activate,omitempty"`
+	ActivateAwait   []string `yaml:"activate_await,omitempty"`
+	ActivateNoAwait []string `yaml:"activate_noawait,omitempty"`
 }
 
 // DebScripts is scripts only available on deb packages.

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -129,11 +129,11 @@ deb:
   # Custom deb triggers
   triggers:
     # register interrest on a trigger activated by another package
-    # (also available: interest-await, interest-noawait)
+    # (also available: interest_await, interest_noawait)
     interest:
       - some-trigger-name
     # activate a trigger for another package
-    # (also available: activate-await, activate-noawait)
+    # (also available: activate_await, activate_noawait)
     activate:
       - another-trigger-name
 ```

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -125,6 +125,17 @@ deb:
   # Custom deb rules script.
   scripts:
     rules: foo.sh
+
+  # Custom deb triggers
+  triggers:
+    # register interrest on a trigger activated by another package
+    # (also available: interest-await, interest-noawait)
+    interest:
+      - some-trigger-name
+    # activate a trigger for another package
+    # (also available: activate-await, activate-noawait)
+    activate:
+      - another-trigger-name
 ```
 
 ## Templating


### PR DESCRIPTION
This pull request adds support for triggers in .deb files. These triggers are commonly used for tasks like rebuilding man pages or `initramfs`. Packages can activate a trigger for other packages or claim interest on triggers activated by other packages. For further information see https://wiki.debian.org/DpkgTriggers, https://man7.org/linux/man-pages/man5/deb-triggers.5.html.

In addition to the feature support, this pull request adds **unit tests**, an **acceptance test** and **documentation**. However, the following changes probably need some feedback before merging:
* The trigger names internally use a `-` (e.g. `activate-noawait`), however I used a `_` (e.g. `activate_noawait`)for the `nfpm` configuration to adhere to yaml conventions.
* `createControl` is now 2 or 3 lines above the line limit enforced by `golangci-lint:funlen`. I think it is still perfectly readable and simple enough, so I decided to ignore the warning by adding `// nolint:funlen`. I hope that's okay.
* In the acceptance test, the package only claims interest for one trigger which is then triggered manually. Activating a trigger is not explicitly tested. The main reason is that `accept()` currently does not support building two packages for the Docker container which would be necessary to test both ways of the trigger mechanism. However, the mechanism is simple enough that I think this test is sufficient, especially since the other cases are somewhat covered by the unit test.
