### PR TITLE
fix: Avoid panic if target is blank/dir and no packager is specified.

### DIFF
--- a/cmd/nfpm/main.go
+++ b/cmd/nfpm/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -58,13 +59,7 @@ func initFile(config string) error {
 	return ioutil.WriteFile(config, []byte(example), 0600)
 }
 
-type parameterError struct {
-	msg string
-}
-
-func (e *parameterError) Error() string {
-	return e.msg
-}
+var errInsufficientParams = errors.New("a packager must be specified if target is a directory or blank")
 
 // nolint:funlen
 func doPackage(configPath, target, packager string) error {
@@ -77,7 +72,7 @@ func doPackage(configPath, target, packager string) error {
 	if packager == "" {
 		ext := filepath.Ext(target)
 		if targetIsADirectory || ext == "" {
-			return &parameterError{"a packager must be specified if target is a directory or blank"}
+			return errInsufficientParams
 		}
 
 		packager = ext[1:]


### PR DESCRIPTION
In #157 I accidentally introduced a bug that results in a panic if `--target` is a directory or blank. This pull request fixes this by printing a useful error message instead. 

A minor issue: The `doPackage()` line limit enforced by `golangci-lint:funlen` is exceeded by 4 lines which in my opinion is acceptable, so i added `// nolint:funlen`.