### PR TITLE
test(#132): Add tests with symlinked files.

### DIFF
--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -542,7 +542,7 @@ func extractFileFromTarGz(tarGzFile []byte, filename string) ([]byte, error) {
 			return nil, err
 		}
 
-		if hdr.Name != strings.TrimLeft(filename, "/") {
+		if path.Join("/", hdr.Name) != path.Join("/", filename) {
 			continue
 		}
 


### PR DESCRIPTION
I tried to fix #132, where the build failed for configurations in which files are referenced via symlinks in macOS. So first I wrote some tests for both `rpm` and `deb` packages to reproduce the issue. However, on my MacBook running Catalina, the packages built perfectly fine and symlinks were followed, so I did not change anything in the packaging process.

I figured, more tests are never bad so this pull request contains the tests with symlinks. If I missed something and the issue does indeed exist, these tests are also still a great starting point for further debugging. Also the tests introduce a handy helper function to extract files from `rpm`s and they also fix a minor issue with the helper function to extract files from `.tar.gz` archives.