### PR TITLE
fix: Do not expand symlink on deb.

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -202,36 +202,58 @@ func createEmptyFoldersInsideTarGz(info *nfpm.Info, out *tar.Writer, created map
 }
 
 func copyToTarAndDigest(tarw *tar.Writer, md5w io.Writer, src, dst string) (int64, error) {
-	file, err := os.OpenFile(src, os.O_RDONLY, 0600) //nolint:gosec
+	stt, err := os.Lstat(src)
 	if err != nil {
 		return 0, errors.Wrap(err, "could not add file to the archive")
 	}
+	var linkname *string
+	switch mode := stt.Mode(); {
+	case mode&os.ModeSymlink != 0:
+		lpath, _ := filepath.EvalSymlinks(src)
+		if lpath[0] != '/' {
+			// relative path is re-resolved relative to src
+			lpath, _ = filepath.Rel(filepath.Dir(src), lpath)
+		}
+		linkname = &lpath
+	}
+
+	file, _ := os.OpenFile(src, os.O_RDONLY, 0600) //nolint:gosec
 	// don't care if it errs while closing...
 	defer file.Close() // nolint: errcheck,gosec
 	info, err := file.Stat()
 	if err != nil {
 		return 0, err
 	}
+
 	if info.IsDir() {
 		// TODO: this should probably return an error
 		return 0, nil
 	}
 	var header = tar.Header{
 		Name:    filepath.ToSlash(dst[1:]),
-		Size:    info.Size(),
 		Mode:    int64(info.Mode()),
 		ModTime: time.Now(),
 		Format:  tar.FormatGNU,
 	}
+	if linkname == nil {
+		header.Size = info.Size()
+	} else {
+		header.Linkname = *linkname
+		header.Typeflag = tar.TypeSymlink
+	}
+
 	if err := tarw.WriteHeader(&header); err != nil {
 		return 0, errors.Wrapf(err, "cannot write header of %s to data.tar.gz", src)
 	}
-	var digest = md5.New() // nolint:gas
-	if _, err := io.Copy(tarw, io.TeeReader(file, digest)); err != nil {
-		return 0, errors.Wrap(err, "failed to copy")
-	}
-	if _, err := fmt.Fprintf(md5w, "%x  %s\n", digest.Sum(nil), header.Name); err != nil {
-		return 0, errors.Wrap(err, "failed to write md5")
+
+	if linkname == nil {
+		var digest = md5.New() // nolint:gas
+		if _, err := io.Copy(tarw, io.TeeReader(file, digest)); err != nil {
+			return 0, errors.Wrap(err, "failed to copy")
+		}
+		if _, err := fmt.Fprintf(md5w, "%x  %s\n", digest.Sum(nil), header.Name); err != nil {
+			return 0, errors.Wrap(err, "failed to write md5")
+		}
 	}
 	return info.Size(), nil
 }

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -202,12 +202,12 @@ func createEmptyFoldersInsideTarGz(info *nfpm.Info, out *tar.Writer, created map
 }
 
 func copyToTarAndDigest(tarw *tar.Writer, md5w io.Writer, src, dst string) (int64, error) {
-	stt, err := os.Lstat(src)
+	info, err := os.Lstat(src)
 	if err != nil {
 		return 0, errors.Wrap(err, "could not add file to the archive")
 	}
 	var linkname *string
-	switch mode := stt.Mode(); {
+	switch mode := info.Mode(); {
 	case mode&os.ModeSymlink != 0:
 		lpath, _ := filepath.EvalSymlinks(src)
 		if lpath[0] != '/' {
@@ -220,10 +220,6 @@ func copyToTarAndDigest(tarw *tar.Writer, md5w io.Writer, src, dst string) (int6
 	file, _ := os.OpenFile(src, os.O_RDONLY, 0600) //nolint:gosec
 	// don't care if it errs while closing...
 	defer file.Close() // nolint: errcheck,gosec
-	info, err := file.Stat()
-	if err != nil {
-		return 0, err
-	}
 
 	if info.IsDir() {
 		// TODO: this should probably return an error

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -238,6 +239,75 @@ func TestDebFileDoesNotExist(t *testing.T) {
 		ioutil.Discard,
 	)
 	assert.EqualError(t, err, "../testdata/whatever.confzzz: file does not exist")
+}
+
+func TestDebFileIsSymlink(t *testing.T) {
+	tdir, _ := ioutil.TempDir("", "fakedir-")
+
+	pwd, _ := os.Getwd()
+	defer func() {
+		os.Chdir(pwd)
+		assert.NoError(t, os.RemoveAll(tdir))
+	}()
+
+	createDebWithSymlink := func(s []string) {
+		reg, sym, treg, tsym := s[0], s[1], s[2], s[3]
+		isAbsSource := reg[0] == '/'
+
+		reg, _ = filepath.Abs(fmt.Sprintf("%s/%s", tdir, reg))
+		os.MkdirAll(filepath.Dir(reg), 0755)
+		ioutil.WriteFile(reg, []byte("whatevs"), 0644)
+
+		sym, _ = filepath.Abs(fmt.Sprintf("%s/%s", tdir, sym))
+		symdir := filepath.Dir(sym)
+		os.MkdirAll(symdir, 0755)
+		symbase := filepath.Base(sym)
+
+		lpath, _ := filepath.Rel(symdir, reg)
+		if isAbsSource {
+			lpath = reg
+		}
+
+		os.Chdir(symdir)
+		os.Symlink(lpath, symbase)
+
+		info := &nfpm.Info{
+			Name:        "foo",
+			Arch:        "amd64",
+			Description: "Foo does things",
+			Version:     "1.0.0",
+			Overridables: nfpm.Overridables{
+				Files: map[string]string{
+					lpath:   treg,
+					symbase: tsym,
+				},
+			},
+		}
+
+		dataTarGz, _, _, err := createDataTarGz(info)
+		assert.NoError(t, err)
+		os.Chdir(pwd)
+
+		_, err = extractFileFromTarGz(dataTarGz, treg[1:])
+		assert.NoError(t, err)
+
+		lnk, err := extractFileFromTarGz(dataTarGz, tsym[1:])
+		assert.Equal(t, lpath, string(lnk))
+		assert.NoError(t, err)
+	}
+
+	createDebWithSymlink([]string{
+		"fake1", "fake1-symlink",
+		"/bin/fake1", "/bin/fake1-symlink"})
+	createDebWithSymlink([]string{
+		"fake2", "bin/fake2-symlink",
+		"/bin/fake2", "/usr/local/bin/fake2-symlink"})
+	createDebWithSymlink([]string{
+		"bin/fake3", "fake3-symlink",
+		"/bin/fake3", "/bin/fake3-symlink"})
+	createDebWithSymlink([]string{
+		"/bin/fake4", "fake4-symlink",
+		"/bin/fake4", "/bin/fake4-symlink"})
 }
 
 func TestDebNoFiles(t *testing.T) {
@@ -512,6 +582,11 @@ func extractFileFromTarGz(tarGzFile []byte, filename string) ([]byte, error) {
 
 		if hdr.Name != filename {
 			continue
+		}
+
+		if hdr.Typeflag == tar.TypeSymlink {
+			// use linkname as content
+			return []byte(hdr.Linkname), nil
 		}
 
 		fileContents, err := ioutil.ReadAll(tr)


### PR DESCRIPTION
This prevents symlinks from being expanded. For deb only.

See #132