### PR TITLE
feat(#183): Support symlinks for deb and rpm.

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -214,7 +214,7 @@ func TestSymlink(t *testing.T) {
 		t.Run(fmt.Sprintf("symlink-%s", format), func(t *testing.T) {
 			t.Parallel()
 			accept(t, acceptParms{
-				Name:       fmt.Sprintf("changelog_%s", format),
+				Name:       fmt.Sprintf("symlink_%s", format),
 				Conf:       "symlink.yaml",
 				Format:     format,
 				Dockerfile: fmt.Sprintf("%s.symlink.dockerfile", format),

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -208,6 +208,21 @@ func TestDebTriggers(t *testing.T) {
 	})
 }
 
+func TestSymlink(t *testing.T) {
+	for _, format := range formats {
+		format := format
+		t.Run(fmt.Sprintf("symlink-%s", format), func(t *testing.T) {
+			t.Parallel()
+			accept(t, acceptParms{
+				Name:       fmt.Sprintf("changelog_%s", format),
+				Conf:       "symlink.yaml",
+				Format:     format,
+				Dockerfile: fmt.Sprintf("%s.symlink.dockerfile", format),
+			})
+		})
+	}
+}
+
 type acceptParms struct {
 	Name       string
 	Conf       string

--- a/acceptance/testdata/deb.symlink.dockerfile
+++ b/acceptance/testdata/deb.symlink.dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu
+ARG package
+COPY ${package} /tmp/foo.deb
+RUN dpkg -i /tmp/foo.deb
+RUN ls -l /path/to/symlink | grep "/path/to/symlink -> /etc/foo/whatever.conf"
+RUN dpkg -r foo

--- a/acceptance/testdata/rpm.symlink.dockerfile
+++ b/acceptance/testdata/rpm.symlink.dockerfile
@@ -1,0 +1,6 @@
+FROM fedora
+ARG package
+COPY ${package} /tmp/foo.rpm
+RUN rpm -ivh /tmp/foo.rpm
+RUN ls -l /path/to/symlink | grep "/path/to/symlink -> /etc/foo/whatever.conf"
+RUN rpm -e foo

--- a/acceptance/testdata/symlink.yaml
+++ b/acceptance/testdata/symlink.yaml
@@ -1,0 +1,12 @@
+name: "foo"
+arch: "amd64"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+files:
+  ../testdata/whatever.conf: "/etc/foo/whatever.conf"
+symlinks:
+  /path/to/symlink: "/etc/foo/whatever.conf"

--- a/cmd/nfpm/main.go
+++ b/cmd/nfpm/main.go
@@ -154,6 +154,8 @@ files:
   ./bar: "/usr/local/bin/bar"
 config_files:
   ./foobar.conf: "/etc/foobar.conf"
+symlinks:
+  /sbin/foo: "/usr/local/bin/foo"
 overrides:
   rpm:
     scripts:

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -153,8 +153,10 @@ func createSymlinksInsideTarGz(info *nfpm.Info, out *tar.Writer, created map[str
 
 		err := newItemInsideTarGz(out, []byte{}, &tar.Header{
 			Name:     src,
-			Typeflag: tar.TypeSymlink,
 			Linkname: dst,
+			Typeflag: tar.TypeSymlink,
+			ModTime:  time.Now(),
+			Format:   tar.FormatGNU,
 		})
 		if err != nil {
 			return err

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -131,7 +131,7 @@ func createDataTarGz(info *nfpm.Info) (dataTarGz, md5sums []byte, instSize int64
 		return nil, nil, 0, err
 	}
 
-	if err := createSymlinksInsideTarGz(info, out); err != nil {
+	if err := createSymlinksInsideTarGz(info, out, created); err != nil {
 		return nil, nil, 0, err
 	}
 
@@ -145,12 +145,16 @@ func createDataTarGz(info *nfpm.Info) (dataTarGz, md5sums []byte, instSize int64
 	return buf.Bytes(), md5buf.Bytes(), instSize, nil
 }
 
-func createSymlinksInsideTarGz(info *nfpm.Info, out *tar.Writer) error {
+func createSymlinksInsideTarGz(info *nfpm.Info, out *tar.Writer, created map[string]bool) error {
 	for src, dst := range info.Symlinks {
+		if err := createTree(out, src, created); err != nil {
+			return err
+		}
+
 		err := newItemInsideTarGz(out, []byte{}, &tar.Header{
-			Name:     src[1:],
+			Name:     src,
 			Typeflag: tar.TypeSymlink,
-			Linkname: dst[1:],
+			Linkname: dst,
 		})
 		if err != nil {
 			return err

--- a/nfpm.go
+++ b/nfpm.go
@@ -153,6 +153,7 @@ type Overridables struct {
 	Conflicts    []string          `yaml:"conflicts,omitempty"`
 	Files        map[string]string `yaml:"files,omitempty"`
 	ConfigFiles  map[string]string `yaml:"config_files,omitempty"`
+	Symlinks     map[string]string `yaml:"symlinks,omitempty"`
 	EmptyFolders []string          `yaml:"empty_folders,omitempty"`
 	Scripts      Scripts           `yaml:"scripts,omitempty"`
 	RPM          RPM               `yaml:"rpm,omitempty"`

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -324,7 +324,6 @@ func addSymlinksInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) {
 			Name:  src,
 			Body:  []byte(dst),
 			Mode:  uint(cpio.S_ISLNK),
-			Type:  rpmpack.GenericFile,
 			MTime: uint32(time.Now().UTC().Unix()),
 			Owner: "root",
 			Group: "root",

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -103,6 +103,8 @@ func (*RPM) Package(info *nfpm.Info, w io.Writer) error {
 		return err
 	}
 
+	addSymlinksInsideRPM(info, rpm)
+
 	if err = addScriptFiles(info, rpm); err != nil {
 		return err
 	}
@@ -313,6 +315,20 @@ func createFilesInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) error {
 		}
 	}
 	return nil
+}
+
+func addSymlinksInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) {
+	for src, dst := range info.Symlinks {
+		rpm.AddFile(rpmpack.RPMFile{
+			Name:  src,
+			Body:  []byte(dst),
+			Mode:  uint(0120000),
+			Type:  rpmpack.GenericFile,
+			MTime: uint32(time.Now().UTC().Unix()),
+			Owner: "root",
+			Group: "root",
+		})
+	}
 }
 
 func copyToRPM(rpm *rpmpack.RPM, src, dst string, config bool) error {

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/rpmpack"
 	"github.com/pkg/errors"
+	"github.com/sassoftware/go-rpmutils/cpio"
 
 	"github.com/goreleaser/chglog"
 
@@ -322,7 +323,7 @@ func addSymlinksInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) {
 		rpm.AddFile(rpmpack.RPMFile{
 			Name:  src,
 			Body:  []byte(dst),
-			Mode:  uint(0120000),
+			Mode:  uint(cpio.S_ISLNK),
 			Type:  rpmpack.GenericFile,
 			MTime: uint32(time.Now().UTC().Unix()),
 			Owner: "root",

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -97,6 +97,10 @@ config_files:
 empty_folders:
 - /var/log/foo
 
+# Symlinks mapping from symlink name inside package to target inside package (overridable)
+symlinks:
+  /sbin/foo: /usr/local/bin/foo
+
 # Scripts to run at specific stages. (overridable)
 scripts:
   preinstall: ./scripts/preinstall.sh


### PR DESCRIPTION
This pull request is an alternative approach to #184 for adding symlinks, as described in my comments in issue #183 (closes #183). In this approach, symlinks can be added as follows:
```
symlinks:
  /path/to/symlink: /path/to/target
```

This approach will not break existing build configurations and supports both package formats. The API is consistent with `config_files` and `empty_folders` and does not promote symlinks in `files` which are broken on the build host that will only eventually work in the context of the package root. Also the changes to the `nfpm.go`, `deb.go` and `rpm.go` are very minimal. Also the separate configuration option makes it clear that symlinks `files:` are followed because otherwise there would be no need for a separate option.

 If we want to develop this approach, I will add tests and documentation. (EDIT: already done)

To discuss:
* In the approach in #184, the symlink target file size is added to the `instSize` for `deb` packages. In this approach nothing is added to `instSize` as symlinks do not have a size (`du -sh` reports `0`). I don't know which is the better option.