### PR TITLE
fix(#130): Don't propagate semver metadata into deb metadata.

### DIFF
--- a/acceptance/testdata/deb.env-var-version.dockerfile
+++ b/acceptance/testdata/deb.env-var-version.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu
 ARG package
 COPY ${package} /tmp/foo.deb
-ENV EXPECTVER=" Version: 1.0.0~0.1.b1+git.abcdefgh"
+ENV EXPECTVER=" Version: 1.0.0~0.1.b1"
 RUN dpkg --info /tmp/foo.deb | grep "Version" > found
 RUN export FOUND_VER="$(cat found)" && \
     echo "Expected: '${EXPECTVER}' :: Found: '${FOUND_VER}'" && \

--- a/nfpm.go
+++ b/nfpm.go
@@ -239,7 +239,6 @@ func WithDefaults(info *Info) *Info {
 		if info.Prerelease == "" && !helpers.IsInt(v.Prerelease()) {
 			info.Prerelease = v.Prerelease()
 		}
-		info.Deb.VersionMetadata = v.Metadata()
 	}
 
 	return info

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -78,7 +78,7 @@ func TestDefaultsVersion(t *testing.T) {
 	assert.Equal(t, "1.0.0", info.Version)
 	assert.Equal(t, "2", info.Release)
 	assert.Equal(t, "beta1", info.Prerelease)
-	assert.Equal(t, "xdg2", info.Deb.VersionMetadata)
+	assert.Equal(t, "", info.Deb.VersionMetadata)
 }
 
 func TestDefaults(t *testing.T) {

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -119,7 +119,7 @@ rpm:
 # can be specified here.
 deb:
   # Custom version metadata.
-  # Default is extracted from `version` if it is semver compatible.
+  # Setting metadata might interfere with version comparisons.
   metadata: xyz2
 
   # Custom deb rules script.


### PR DESCRIPTION
This pull request closes #130 by not propagating the semver metadata info the `Deb.Metadata` field. As described in the corresponding issue, this is the expected behaviour for `deb` files.

EDIT: changed it to wip because I actually don't even know why `Deb.Metadata` exists if it shouldn't be included in the version.