### PR TITLE
fix: Remove RPM group default.

### DIFF
--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -217,7 +217,7 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		URL:         info.Homepage,
 		Vendor:      info.Vendor,
 		Packager:    info.Maintainer,
-		Group:       defaultTo(info.RPM.Group, "Development/Tools"),
+		Group:       info.RPM.Group,
 		Provides:    provides,
 		Recommends:  recommends,
 		Requires:    depends,

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -105,7 +105,7 @@ func TestRPM(t *testing.T) {
 
 	group, err := rpm.Header.GetString(rpmutils.GROUP)
 	require.NoError(t, err)
-	assert.Equal(t, "Development/Tools", group)
+	assert.Equal(t, "", group)
 
 	summary, err := rpm.Header.GetString(rpmutils.SUMMARY)
 	require.NoError(t, err)
@@ -114,6 +114,29 @@ func TestRPM(t *testing.T) {
 	description, err := rpm.Header.GetString(rpmutils.DESCRIPTION)
 	require.NoError(t, err)
 	assert.Equal(t, "Foo does things", description)
+}
+
+func TestRPMGroup(t *testing.T) {
+	f, err := ioutil.TempFile("", "test.rpm")
+	defer func() {
+		_ = f.Close()
+		err = os.Remove(f.Name())
+		assert.NoError(t, err)
+	}()
+
+	info := exampleInfo()
+	info.RPM.Group = "Unspecified"
+
+	require.NoError(t, Default.Package(info, f))
+
+	file, err := os.OpenFile(f.Name(), os.O_RDONLY, 0600) //nolint:gosec
+	require.NoError(t, err)
+	rpm, err := rpmutils.ReadRpm(file)
+	require.NoError(t, err)
+
+	group, err := rpm.Header.GetString(rpmutils.GROUP)
+	require.NoError(t, err)
+	assert.Equal(t, "Unspecified", group)
 }
 
 func TestWithRPMTags(t *testing.T) {

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -112,8 +112,9 @@ scripts:
 # All fields described bellow, plus all fields above marked as `overridable`
 # can be specified here.
 rpm:
-  # Group.
-  group: root
+  # The package group. This option is deprecated by most distros
+  # but required by old distros like CentOS 5 / EL 5 and earlier.
+  group: Unspecified
 
   # Compression algorithm.
   compression: lzma


### PR DESCRIPTION
This pull request removes the default RPM group tag value, adds documentation and tests for both a blank and a populated group tag. Closes #193.

Also making sure that there is always an new pull request 😆 