### PR TITLE
fix: Remove leading slashes from files in .tag.gz files in deb.

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -204,7 +204,7 @@ func createFilesInsideTarGz(info *nfpm.Info, out *tar.Writer, created map[string
 		}
 
 		// https://www.debian.org/doc/manuals/developers-reference/pkgs.de.html#recording-changes-in-the-package
-		changelogName := fmt.Sprintf("usr/share/doc/%s/changelog.gz", info.Name)
+		changelogName := fmt.Sprintf("/usr/share/doc/%s/changelog.gz", info.Name)
 		if err = createTree(out, changelogName, created); err != nil {
 			return md5buf, 0, err
 		}
@@ -392,7 +392,7 @@ func newItemInsideTarGz(out *tar.Writer, content []byte, header *tar.Header) err
 
 func newFileInsideTarGz(out *tar.Writer, name string, content []byte) error {
 	return newItemInsideTarGz(out, content, &tar.Header{
-		Name:     filepath.ToSlash(name),
+		Name:     strings.TrimLeft(filepath.ToSlash(name), "/"),
 		Size:     int64(len(content)),
 		Mode:     0644,
 		ModTime:  time.Now(),

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -154,7 +154,7 @@ func createSymlinksInsideTarGz(info *nfpm.Info, out *tar.Writer, created map[str
 		}
 
 		err := newItemInsideTarGz(out, []byte{}, &tar.Header{
-			Name:     src,
+			Name:     strings.TrimLeft(src, "/"),
 			Linkname: dst,
 			Typeflag: tar.TypeSymlink,
 			ModTime:  time.Now(),
@@ -204,7 +204,7 @@ func createFilesInsideTarGz(info *nfpm.Info, out *tar.Writer, created map[string
 		}
 
 		// https://www.debian.org/doc/manuals/developers-reference/pkgs.de.html#recording-changes-in-the-package
-		changelogName := fmt.Sprintf("/usr/share/doc/%s/changelog.gz", info.Name)
+		changelogName := fmt.Sprintf("usr/share/doc/%s/changelog.gz", info.Name)
 		if err = createTree(out, changelogName, created); err != nil {
 			return md5buf, 0, err
 		}


### PR DESCRIPTION
In earlier pull requests, I accidentally added symlink and changelog files to the `deb` `.tar.gz` files with a leading `/`. This pull requests removes these leading `/`s such that no warning is displayed by `tar` anymore when unpacking. I also added a tests that assures that no files included in the data and control `.tar.gz` starts with `/`.