### PR TITLE
docs: Give overrides examples for depends with version constraints.

### DIFF
--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -110,9 +110,17 @@ scripts:
 
 # All fields above marked as `overridable` can be overriden for a given package format in this section.
 overrides:
+  # The depends override can for example be used to provide version constraints for dependencies where
+  # different package formats use different versions or for dependencies that are named differently.
   deb:
+    depends:
+      - baz (>= 1.2.3-0)
+      - some-lib-dev
     # ...
   rpm:
+    depends:
+      - baz >= 1.2.3-0
+      - some-lib-devel
     # ...
   apk:
     # ...


### PR DESCRIPTION
This PR adds docs with examples for `depends` `overrides`:
* Version constraints with different notations between formats (as discussed in #200)
* Packages that are named differently between distros