### PR TITLE
fix: Correctly handle version, release and prerelease for RPMs.

### DIFF
--- a/acceptance/testdata/rpm.env-var-version.dockerfile
+++ b/acceptance/testdata/rpm.env-var-version.dockerfile
@@ -1,8 +1,8 @@
 FROM fedora
 ARG package
 COPY ${package} /tmp/foo.rpm
-ENV EXPECTVER="Version : 1.0.0" \
-    EXPECTREL="Release : 0.1.0.1.b1"
+ENV EXPECTVER="Version : 1.0.0~0.1.b1" \
+    EXPECTREL="Release : 1"
 RUN rpm -qpi /tmp/foo.rpm | sed -e 's/ \+/ /g' | grep "Version" > found.ver
 RUN rpm -qpi /tmp/foo.rpm | sed -e 's/ \+/ /g' | grep "Release" > found.rel
 RUN export FOUND_VER="$(cat found.ver)" && \

--- a/nfpm.go
+++ b/nfpm.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
@@ -230,10 +229,7 @@ func WithDefaults(info *Info) *Info {
 	// and support proper ordering for both rpm and deb
 	if v, err := semver.NewVersion(info.Version); err == nil {
 		info.Version = fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch())
-		if info.Release == "" && isInt(v.Prerelease()) {
-			info.Release = v.Prerelease()
-		}
-		if info.Prerelease == "" && !isInt(v.Prerelease()) {
+		if info.Prerelease == "" {
 			info.Prerelease = v.Prerelease()
 		}
 	}
@@ -258,9 +254,4 @@ func (info *Info) GetChangeLog() (log *chglog.PackageChangeLog, err error) {
 		Name:    info.Name,
 		Entries: entries,
 	}, nil
-}
-
-func isInt(s string) bool {
-	_, err := strconv.Atoi(s)
-	return err == nil
 }

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -52,12 +52,12 @@ func TestDefaultsVersion(t *testing.T) {
 	assert.Equal(t, "rc1", info.Prerelease)
 
 	info = &Info{
-		Version: "v1.0.0-1",
+		Version: "v1.0.0-beta1",
 	}
 	info = WithDefaults(info)
 	assert.Equal(t, "1.0.0", info.Version)
-	assert.Equal(t, "1", info.Release)
-	assert.Equal(t, "", info.Prerelease)
+	assert.Equal(t, "", info.Release)
+	assert.Equal(t, "beta1", info.Prerelease)
 
 	info = &Info{
 		Version:    "v1.0.0-1",

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -73,12 +73,9 @@ func ensureValidArch(info *nfpm.Info) *nfpm.Info {
 func (*RPM) ConventionalFileName(info *nfpm.Info) string {
 	info = ensureValidArch(info)
 
-	version := info.Version
+	version := formatVersion(info)
 	if info.Release != "" {
 		version += "-" + info.Release
-	}
-	if info.Prerelease != "" {
-		version += "~" + info.Prerelease
 	}
 
 	// name-version-release.architecture.rpm
@@ -208,8 +205,8 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		Name:        info.Name,
 		Summary:     strings.Split(info.Description, "\n")[0],
 		Description: info.Description,
-		Version:     info.Version,
-		Release:     releaseFor(info),
+		Version:     formatVersion(info),
+		Release:     defaultTo(info.Release, "1"),
 		Epoch:       uint32(epoch),
 		Arch:        info.Arch,
 		OS:          info.Platform,
@@ -230,12 +227,12 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 	}, nil
 }
 
-func releaseFor(info *nfpm.Info) string {
-	var release = defaultTo(info.Release, "1")
-	if info.Prerelease != "" {
-		release = fmt.Sprintf("%s.%s", defaultTo(info.Release, "0.1"), info.Prerelease)
+func formatVersion(info *nfpm.Info) string {
+	if info.Prerelease == "" {
+		return info.Version
 	}
-	return release
+
+	return info.Version + "~" + info.Prerelease
 }
 
 func defaultTo(in, def string) string {

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -212,24 +212,41 @@ func TestRPMVersionWithRelease(t *testing.T) {
 func TestRPMVersionWithPrerelease(t *testing.T) {
 	// https://fedoraproject.org/wiki/Package_Versioning_Examples#Complex_versioning_examples
 	info := exampleInfo()
-	info.Version = "1.0.0" //nolint:golint,goconst
-	info.Prerelease = "rc1"
+
+	info.Version = "1.0.0"
+	info.Prerelease = "rc1" // nolint:goconst
 	meta, err := buildRPMMeta(info)
 	require.NoError(t, err)
-	assert.Equal(t, "1.0.0", meta.Version)
-	assert.Equal(t, "0.1.rc1", meta.Release)
+	assert.Equal(t, "1.0.0~rc1", meta.Version)
+	assert.Equal(t, "1", meta.Release)
+
+	info.Version = "1.0.0~rc1"
+	info.Prerelease = ""
+	meta, err = buildRPMMeta(info)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0~rc1", meta.Version)
+	assert.Equal(t, "1", meta.Release)
 }
 
 func TestRPMVersionWithReleaseAndPrerelease(t *testing.T) {
 	// https://fedoraproject.org/wiki/Package_Versioning_Examples#Complex_versioning_examples
 	info := exampleInfo()
-	info.Version = "1.0.0" //nolint:golint,goconst
+
+	info.Version = "1.0.0"
 	info.Release = "0.2"
 	info.Prerelease = "rc1"
 	meta, err := buildRPMMeta(info)
 	require.NoError(t, err)
-	assert.Equal(t, "1.0.0", meta.Version)
-	assert.Equal(t, "0.2.rc1", meta.Release)
+	assert.Equal(t, "1.0.0~rc1", meta.Version)
+	assert.Equal(t, "0.2", meta.Release)
+
+	info.Version = "1.0.0~rc1"
+	info.Release = "0.2"
+	info.Prerelease = ""
+	meta, err = buildRPMMeta(info)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0~rc1", meta.Version)
+	assert.Equal(t, "0.2", meta.Release)
 }
 
 func TestWithInvalidEpoch(t *testing.T) {
@@ -367,7 +384,7 @@ func TestRPMConventionalFileName(t *testing.T) {
 		{Version: "1.2.3", Release: "4", Prerelease: "",
 			Expected: fmt.Sprintf("%s-1.2.3-4.%s.rpm", info.Name, info.Arch)},
 		{Version: "1.2.3", Release: "4", Prerelease: "5",
-			Expected: fmt.Sprintf("%s-1.2.3-4~5.%s.rpm", info.Name, info.Arch)},
+			Expected: fmt.Sprintf("%s-1.2.3~5-4.%s.rpm", info.Name, info.Arch)},
 		{Version: "1.2.3", Release: "", Prerelease: "5",
 			Expected: fmt.Sprintf("%s-1.2.3~5.%s.rpm", info.Name, info.Arch)},
 	}


### PR DESCRIPTION
This pull request fixes (hopefully) the version, release and prerelease handling for RPMs. Also, globally for all package formats, a semver prerelease present in `info.Version` will not populate `info.Release` anymore since `info.Version` should contain version information of the packaged subject and not the package itself.

Closes #131. Maybe we should also wait for feedback from @boogie-byte before merging.