### PR TITLE
feat: Introduce version_metadata for all packagers (deprecate deb.metadata)

### DIFF
--- a/acceptance/testdata/apk.env-var-version.dockerfile
+++ b/acceptance/testdata/apk.env-var-version.dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk
-ENV EXPECTVER="foo-1.0.0~0.1.b1 description:"
+ENV EXPECTVER="foo-1.0.0~0.1.b1+git.abcdefgh description:"
 RUN apk info foo | grep "foo-" | grep " description:" > found
 RUN export FOUND_VER="$(cat found)" && \
     echo "Expected: '${EXPECTVER}' :: Found: '${FOUND_VER}'" && \

--- a/acceptance/testdata/deb.env-var-version.dockerfile
+++ b/acceptance/testdata/deb.env-var-version.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu
 ARG package
 COPY ${package} /tmp/foo.deb
-ENV EXPECTVER=" Version: 1.0.0~0.1.b1"
+ENV EXPECTVER=" Version: 1.0.0~0.1.b1+git.abcdefgh"
 RUN dpkg --info /tmp/foo.deb | grep "Version" > found
 RUN export FOUND_VER="$(cat found)" && \
     echo "Expected: '${EXPECTVER}' :: Found: '${FOUND_VER}'" && \

--- a/acceptance/testdata/rpm.env-var-version.dockerfile
+++ b/acceptance/testdata/rpm.env-var-version.dockerfile
@@ -1,7 +1,7 @@
 FROM fedora
 ARG package
 COPY ${package} /tmp/foo.rpm
-ENV EXPECTVER="Version : 1.0.0~0.1.b1" \
+ENV EXPECTVER="Version : 1.0.0~0.1.b1+git.abcdefgh" \
     EXPECTREL="Release : 1"
 RUN rpm -qpi /tmp/foo.rpm | sed -e 's/ \+/ /g' | grep "Version" > found.ver
 RUN rpm -qpi /tmp/foo.rpm | sed -e 's/ \+/ /g' | grep "Release" > found.rel

--- a/apk/apk.go
+++ b/apk/apk.go
@@ -77,7 +77,25 @@ type Apk struct{}
 
 func (a *Apk) ConventionalFileName(info *nfpm.Info) string {
 	// TODO: verify this
-	return fmt.Sprintf("%s_%s_%s.apk", info.Name, info.Version, info.Arch)
+	arch, ok := archToAlpine[info.Arch]
+	if !ok {
+		arch = info.Arch
+	}
+
+	version := info.Version
+	if info.Release != "" {
+		version += "-" + info.Release
+	}
+
+	if info.Prerelease != "" {
+		version += "~" + info.Prerelease
+	}
+
+	if info.VersionMetadata != "" {
+		version += "+" + info.VersionMetadata
+	}
+
+	return fmt.Sprintf("%s_%s_%s.apk", info.Name, version, arch)
 }
 
 // Package writes a new apk package to the given writer using the given info.
@@ -453,7 +471,7 @@ pkgname = {{.Info.Name}}
 pkgver = {{ if .Info.Epoch}}{{ .Info.Epoch }}:{{ end }}{{.Info.Version}}
          {{- if .Info.Release}}-{{ .Info.Release }}{{- end }}
          {{- if .Info.Prerelease}}~{{ .Info.Prerelease }}{{- end }}
-         {{- if .Info.Deb.VersionMetadata}}+{{ .Info.Deb.VersionMetadata }}{{- end }}
+         {{- if .Info.VersionMetadata}}+{{ .Info.VersionMetadata }}{{- end }}
 arch = {{.Info.Arch}}
 size = {{.InstalledSize}}
 pkgdesc = {{multiline .Info.Description}}

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -61,8 +61,13 @@ func (*Deb) ConventionalFileName(info *nfpm.Info) string {
 	if info.Release != "" {
 		version += "-" + info.Release
 	}
+
 	if info.Prerelease != "" {
 		version += "~" + info.Prerelease
+	}
+
+	if info.VersionMetadata != "" {
+		version += "+" + info.VersionMetadata
 	}
 
 	// package_version_architecture.package-type
@@ -502,7 +507,7 @@ Package: {{.Info.Name}}
 Version: {{ if .Info.Epoch}}{{ .Info.Epoch }}:{{ end }}{{.Info.Version}}
          {{- if .Info.Release}}-{{ .Info.Release }}{{- end }}
          {{- if .Info.Prerelease}}~{{ .Info.Prerelease }}{{- end }}
-         {{- if .Info.Deb.VersionMetadata}}+{{ .Info.Deb.VersionMetadata }}{{- end }}
+         {{- if .Info.VersionMetadata}}+{{ .Info.VersionMetadata }}{{- end }}
 Section: {{.Info.Section}}
 Priority: {{.Info.Priority}}
 Architecture: {{.Info.Arch}}

--- a/nfpm.go
+++ b/nfpm.go
@@ -116,24 +116,25 @@ func (c *Config) Validate() error {
 
 // Info contains information about a single package.
 type Info struct {
-	Overridables `yaml:",inline"`
-	Name         string `yaml:"name,omitempty"`
-	Arch         string `yaml:"arch,omitempty"`
-	Platform     string `yaml:"platform,omitempty"`
-	Epoch        string `yaml:"epoch,omitempty"`
-	Version      string `yaml:"version,omitempty"`
-	Release      string `yaml:"release,omitempty"`
-	Prerelease   string `yaml:"prerelease,omitempty"`
-	Section      string `yaml:"section,omitempty"`
-	Priority     string `yaml:"priority,omitempty"`
-	Maintainer   string `yaml:"maintainer,omitempty"`
-	Description  string `yaml:"description,omitempty"`
-	Vendor       string `yaml:"vendor,omitempty"`
-	Homepage     string `yaml:"homepage,omitempty"`
-	License      string `yaml:"license,omitempty"`
-	Bindir       string `yaml:"bindir,omitempty"` // Deprecated: this does nothing. TODO: remove.
-	Changelog    string `yaml:"changelog,omitempty"`
-	Target       string `yaml:"-"`
+	Overridables    `yaml:",inline"`
+	Name            string `yaml:"name,omitempty"`
+	Arch            string `yaml:"arch,omitempty"`
+	Platform        string `yaml:"platform,omitempty"`
+	Epoch           string `yaml:"epoch,omitempty"`
+	Version         string `yaml:"version,omitempty"`
+	Release         string `yaml:"release,omitempty"`
+	Prerelease      string `yaml:"prerelease,omitempty"`
+	VersionMetadata string `yaml:"version_metadata,omitempty"`
+	Section         string `yaml:"section,omitempty"`
+	Priority        string `yaml:"priority,omitempty"`
+	Maintainer      string `yaml:"maintainer,omitempty"`
+	Description     string `yaml:"description,omitempty"`
+	Vendor          string `yaml:"vendor,omitempty"`
+	Homepage        string `yaml:"homepage,omitempty"`
+	License         string `yaml:"license,omitempty"`
+	Bindir          string `yaml:"bindir,omitempty"` // Deprecated: this does nothing. TODO: remove.
+	Changelog       string `yaml:"changelog,omitempty"`
+	Target          string `yaml:"-"`
 }
 
 // Overridables contain the field which are overridable in a package.
@@ -165,7 +166,7 @@ type RPM struct {
 type Deb struct {
 	Scripts         DebScripts  `yaml:"scripts,omitempty"`
 	Triggers        DebTriggers `yaml:"triggers,omitempty"`
-	VersionMetadata string      `yaml:"metadata,omitempty"`
+	VersionMetadata string      `yaml:"metadata,omitempty"` // Deprecated: Moved to Info
 }
 
 // DebTriggers contains triggers only available for deb packages.
@@ -213,6 +214,18 @@ func Validate(info *Info) error {
 	if info.Version == "" {
 		return ErrFieldEmpty{"version"}
 	}
+
+	// deprecation warnings
+	if info.Deb.VersionMetadata != "" {
+		fmt.Fprintln(os.Stderr,
+			"Warning: deb.metadata is deprecated and will be removed in a future version "+
+				"(moved to version_metadata)")
+	}
+
+	if info.Bindir != "" {
+		fmt.Fprintln(os.Stderr, "Warning: bindir is deprecated and will be removed in a future version")
+	}
+
 	return nil
 }
 
@@ -231,6 +244,10 @@ func WithDefaults(info *Info) *Info {
 		info.Version = fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch())
 		if info.Prerelease == "" {
 			info.Prerelease = v.Prerelease()
+		}
+
+		if info.VersionMetadata == "" {
+			info.VersionMetadata = v.Metadata()
 		}
 	}
 

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -228,11 +228,17 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 }
 
 func formatVersion(info *nfpm.Info) string {
-	if info.Prerelease == "" {
-		return info.Version
+	version := info.Version
+
+	if info.Prerelease != "" {
+		version += "~" + info.Prerelease
 	}
 
-	return info.Version + "~" + info.Prerelease
+	if info.VersionMetadata != "" {
+		version += "+" + info.VersionMetadata
+	}
+
+	return version
 }
 
 func defaultTo(in, def string) string {

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -22,13 +22,17 @@ version: v1.2.3
 # Default is extracted from `version` if it is semver compatible.
 epoch: 2
 
-# Version Release.
-# Default is extracted from `version` if it is semver compatible.
-release: 1
-
 # Version Prerelease.
 # Default is extracted from `version` if it is semver compatible.
 prerelease: beta1
+
+# Version Metadata (previously deb.metadata).
+# Default is extracted from `version` if it is semver compatible.
+# Setting metadata might interfere with version comparisons depending on the packager.
+version_metadata: git
+
+# Version Release.
+release: 1
 
 # Section.
 section: default
@@ -141,10 +145,6 @@ rpm:
 
 # Custon configuration applied only to the Deb packager.
 deb:
-  # Custom version metadata.
-  # Setting metadata might interfere with version comparisons.
-  metadata: xyz2
-
   # Custom deb rules script.
   scripts:
     rules: foo.sh


### PR DESCRIPTION
I added the global config field `VersionMetadata` for all packagers. I chose `version_metadata` for the YAML field because metadata is such a generic term that most people won't associate it with the version otherwise. The `deb` packager already supported this and the `apk` formatter borrowed it from the `deb`-specific option which was not ideal.

`Deb.VersionMetadata` is now deprecated an a warning will be emitted to stderr if it is still set (same for `BinDir`).


If not explicitly set, the `VersionMetadata` can be populated from `Version` semver metadata.

Also the tests and conventional file names are updated.