### PR TITLE
fix: Ensure relative path prefix for deb packages

### DIFF
--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -661,7 +661,7 @@ func TestSymlink(t *testing.T) {
 	assert.Equal(t, symlinkTarget, packagedSymlinkHeader.Linkname)
 }
 
-func TestNoLeadingSlashInTarGzFiles(t *testing.T) {
+func TestEnsureRelativePrefixInTarGzFiles(t *testing.T) {
 	info := exampleInfo()
 	info.Symlinks = map[string]string{
 		"/symlink/to/fake.txt": "/usr/share/doc/fake/fake.txt",
@@ -670,14 +670,14 @@ func TestNoLeadingSlashInTarGzFiles(t *testing.T) {
 
 	dataTarGz, md5sums, instSize, err := createDataTarGz(info)
 	require.NoError(t, err)
-	testNoLeadingSlashInTarGzFiles(t, dataTarGz)
+	testRelativePathPrefixInTarGzFiles(t, dataTarGz)
 
 	controlTarGz, err := createControl(instSize, md5sums, info)
 	require.NoError(t, err)
-	testNoLeadingSlashInTarGzFiles(t, controlTarGz)
+	testRelativePathPrefixInTarGzFiles(t, controlTarGz)
 }
 
-func testNoLeadingSlashInTarGzFiles(t *testing.T, tarGzFile []byte) {
+func testRelativePathPrefixInTarGzFiles(t *testing.T, tarGzFile []byte) {
 	tarFile, err := gzipInflate(tarGzFile)
 	require.NoError(t, err)
 
@@ -689,7 +689,7 @@ func testNoLeadingSlashInTarGzFiles(t *testing.T, tarGzFile []byte) {
 		}
 		require.NoError(t, err)
 
-		assert.False(t, strings.HasPrefix(hdr.Name, "/"), "%s starts with /", hdr.Name)
+		assert.True(t, strings.HasPrefix(hdr.Name, "./"), "%s does not start with './'", hdr.Name)
 	}
 }
 


### PR DESCRIPTION
This patch ensures that all items contained in tar.gz files in Debian
packages have a relative path prefix, so the names all start with "./".
While this is not strictly required for a Debian package to function,
detecting a changed config file fails with an error messages similar to
the following:

    tar: ./etc/default/conffilename: Not found in archive

It seems to fail extracting config files for checking if they have been
modified by the system administrator.

All reference documentation that I was able to find (e.g. in the Debian
Handbook[1]) shows that all paths contained in either data.tar.gz and
control.tar.gz have the prefix "./".

I've verified that with this change, config files works as expected.

[1] https://debian-handbook.info/browse/stable/packaging-system.html#sect.binary-package-structure