### PR TITLE
fix: Change upgrade to update in changelog dockerfile

### DIFF
--- a/acceptance/testdata/deb.changelog.dockerfile
+++ b/acceptance/testdata/deb.changelog.dockerfile
@@ -5,7 +5,7 @@ ARG package
 # so we have to remove that rule
 RUN rm /etc/dpkg/dpkg.cfg.d/excludes
 COPY ${package} /tmp/foo.deb
-RUN apt upgrade -y
+RUN apt update -y
 RUN apt install -y gzip
 RUN dpkg -i /tmp/foo.deb
 RUN zcat "/usr/share/doc/foo/changelog.gz" | grep "Carlos A Becker <pkg@carlosbecker.com>"


### PR DESCRIPTION
Change `apt upgrade` to `apt update` before installing a package. This was a typo and now this test should also run faster.