### PR TITLE
refactor: remove pkg/errors

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -257,6 +257,8 @@ func createSignature(signatureTgz io.Writer, info *nfpm.Info, controlSHA1Digest 
 	return nil
 }
 
+var errNoKeyAddress = errors.New("key name not set and maintainer mail address empty")
+
 func createSignatureBuilder(digest []byte, info *nfpm.Info) func(*tar.Writer) error {
 	return func(tw *tar.Writer) error {
 		signature, err := sign.RSASignSHA1Digest(digest,
@@ -272,7 +274,7 @@ func createSignatureBuilder(digest []byte, info *nfpm.Info) func(*tar.Writer) er
 			if err != nil {
 				return fmt.Errorf("key name not set and unable to parse maintainer mail address: %w", err)
 			} else if addr.Address == "" {
-				return errors.New("key name not set and maintainer mail address empty")
+				return errNoKeyAddress
 			}
 
 			keyname = addr.Address + ".rsa.pub"

--- a/apk/apk.go
+++ b/apk/apk.go
@@ -33,6 +33,7 @@ import (
 	"crypto/sha1" // nolint:gosec
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -46,13 +47,9 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/goreleaser/nfpm/internal/files"
-
-	"github.com/goreleaser/nfpm/internal/sign"
-
-	"github.com/pkg/errors"
-
 	"github.com/goreleaser/nfpm"
+	"github.com/goreleaser/nfpm/internal/files"
+	"github.com/goreleaser/nfpm/internal/sign"
 )
 
 // nolint: gochecknoinits
@@ -273,7 +270,7 @@ func createSignatureBuilder(digest []byte, info *nfpm.Info) func(*tar.Writer) er
 		if keyname == "" {
 			addr, err := mail.ParseAddress(info.Maintainer)
 			if err != nil {
-				return errors.Wrap(err, "key name not set and unable to parse maintainer mail address")
+				return fmt.Errorf("key name not set and unable to parse maintainer mail address: %w", err)
 			} else if addr.Address == "" {
 				return errors.New("key name not set and maintainer mail address empty")
 			}
@@ -370,10 +367,10 @@ func newScriptInsideTarGz(out *tar.Writer, path, dest string) error {
 
 func newItemInsideTarGz(out *tar.Writer, content []byte, header *tar.Header) error {
 	if err := out.WriteHeader(header); err != nil {
-		return errors.Wrapf(err, "cannot write header of %s file to control.tar.gz", header.Name)
+		return fmt.Errorf("cannot write header of %s file to control.tar.gz: %w", header.Name, err)
 	}
 	if _, err := out.Write(content); err != nil {
-		return errors.Wrapf(err, "cannot write %s file to control.tar.gz", header.Name)
+		return fmt.Errorf("cannot write %s file to control.tar.gz: %w", header.Name, err)
 	}
 	return nil
 }
@@ -444,7 +441,7 @@ func createSymlinksInsideTarGz(info *nfpm.Info, out *tar.Writer, created map[str
 func copyToTarAndDigest(src, dst string, tw *tar.Writer, sizep *int64, created map[string]bool) error {
 	file, err := os.OpenFile(src, os.O_RDONLY, 0600) //nolint:gosec
 	if err != nil {
-		return errors.Wrap(err, "could not add file to the archive")
+		return fmt.Errorf("could not add file to the archive: %w", err)
 	}
 	// don't care if it errs while closing...
 	defer file.Close() // nolint: errcheck
@@ -501,7 +498,7 @@ func createTree(tarw *tar.Writer, dst string, created map[string]bool) error {
 			Format:   tar.FormatGNU,
 			ModTime:  time.Now(),
 		}); err != nil {
-			return errors.Wrap(err, "failed to create folder")
+			return fmt.Errorf("failed to create folder: %w", err)
 		}
 		created[path] = true
 	}

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -177,7 +177,7 @@ func TestFileDoesNotExist(t *testing.T) {
 		}),
 		ioutil.Discard,
 	)
-	assert.EqualError(t, err, "../testdata/whatever.confzzz: file does not exist")
+	assert.EqualError(t, err, "glob failed: ../testdata/whatever.confzzz: file does not exist")
 }
 
 func TestNoFiles(t *testing.T) {

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/md5" // nolint:gas
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,14 +17,10 @@ import (
 	"time"
 
 	"github.com/blakesmith/ar"
-	"github.com/pkg/errors"
-
+	"github.com/goreleaser/chglog"
+	"github.com/goreleaser/nfpm"
 	"github.com/goreleaser/nfpm/internal/files"
 	"github.com/goreleaser/nfpm/internal/sign"
-
-	"github.com/goreleaser/chglog"
-
-	"github.com/goreleaser/nfpm"
 )
 
 // nolint: gochecknoinits
@@ -96,19 +93,19 @@ func (*Deb) Package(info *nfpm.Info, deb io.Writer) (err error) {
 
 	var w = ar.NewWriter(deb)
 	if err := w.WriteGlobalHeader(); err != nil {
-		return errors.Wrap(err, "cannot write ar header to deb file")
+		return fmt.Errorf("cannot write ar header to deb file: %w", err)
 	}
 
 	if err := addArFile(w, "debian-binary", debianBinary); err != nil {
-		return errors.Wrap(err, "cannot pack debian-binary")
+		return fmt.Errorf("cannot pack debian-binary: %w", err)
 	}
 
 	if err := addArFile(w, "control.tar.gz", controlTarGz); err != nil {
-		return errors.Wrap(err, "cannot add control.tar.gz to deb")
+		return fmt.Errorf("cannot add control.tar.gz to deb: %w", err)
 	}
 
 	if err := addArFile(w, "data.tar.gz", dataTarGz); err != nil {
-		return errors.Wrap(err, "cannot add data.tar.gz to deb")
+		return fmt.Errorf("cannot add data.tar.gz to deb: %w", err)
 	}
 
 	if info.Deb.Signature.KeyFile != "" {
@@ -127,11 +124,15 @@ func (*Deb) Package(info *nfpm.Info, deb io.Writer) (err error) {
 		}
 
 		if sigType != "origin" && sigType != "maint" && sigType != "archive" {
-			return &nfpm.ErrSigningFailure{Err: errors.New("invalid signature type")}
+			return &nfpm.ErrSigningFailure{
+				Err: errors.New("invalid signature type"),
+			}
 		}
 
 		if err := addArFile(w, "_gpg"+sigType, sig); err != nil {
-			return &nfpm.ErrSigningFailure{Err: errors.Wrap(err, "add signature to ar file")}
+			return &nfpm.ErrSigningFailure{
+				Err: fmt.Errorf("add signature to ar file: %w", err),
+			}
 		}
 	}
 
@@ -146,7 +147,7 @@ func addArFile(w *ar.Writer, name string, body []byte) error {
 		ModTime: time.Now(),
 	}
 	if err := w.WriteHeader(&header); err != nil {
-		return errors.Wrap(err, "cannot write file header")
+		return fmt.Errorf("cannot write file header: %w", err)
 	}
 	_, err := w.Write(body)
 	return err
@@ -177,10 +178,10 @@ func createDataTarGz(info *nfpm.Info) (dataTarGz, md5sums []byte, instSize int64
 	}
 
 	if err := out.Close(); err != nil {
-		return nil, nil, 0, errors.Wrap(err, "closing data.tar.gz")
+		return nil, nil, 0, fmt.Errorf("closing data.tar.gz: %w", err)
 	}
 	if err := compress.Close(); err != nil {
-		return nil, nil, 0, errors.Wrap(err, "closing data.tar.gz")
+		return nil, nil, 0, fmt.Errorf("closing data.tar.gz: %w", err)
 	}
 
 	return buf.Bytes(), md5buf.Bytes(), instSize, nil
@@ -263,7 +264,7 @@ func createEmptyFoldersInsideTarGz(info *nfpm.Info, out *tar.Writer, created map
 func copyToTarAndDigest(tarw *tar.Writer, md5w io.Writer, src, dst string) (int64, error) {
 	file, err := os.OpenFile(src, os.O_RDONLY, 0600) //nolint:gosec
 	if err != nil {
-		return 0, errors.Wrap(err, "could not add file to the archive")
+		return 0, fmt.Errorf("could not add file to the archive: %w", err)
 	}
 	// don't care if it errs while closing...
 	defer file.Close() // nolint: errcheck,gosec
@@ -283,14 +284,14 @@ func copyToTarAndDigest(tarw *tar.Writer, md5w io.Writer, src, dst string) (int6
 		Format:  tar.FormatGNU,
 	}
 	if err := tarw.WriteHeader(&header); err != nil {
-		return 0, errors.Wrapf(err, "cannot write header of %s to data.tar.gz", src)
+		return 0, fmt.Errorf("cannot write header of %s to data.tar.gz: %w", src, err)
 	}
 	var digest = md5.New() // nolint:gas
 	if _, err := io.Copy(tarw, io.TeeReader(file, digest)); err != nil {
-		return 0, errors.Wrap(err, "failed to copy")
+		return 0, fmt.Errorf("failed to copy: %w", err)
 	}
 	if _, err := fmt.Fprintf(md5w, "%x  %s\n", digest.Sum(nil), header.Name); err != nil {
-		return 0, errors.Wrap(err, "failed to write md5")
+		return 0, fmt.Errorf("failed to write md5: %w", err)
 	}
 	return info.Size(), nil
 }
@@ -313,7 +314,7 @@ func createChangelogInsideTarGz(tarw *tar.Writer, md5w io.Writer, created map[st
 	}
 
 	if err = out.Close(); err != nil {
-		return 0, errors.Wrap(err, "closing changelog.gz")
+		return 0, fmt.Errorf("closing changelog.gz: %w", err)
 	}
 
 	changelogData := buf.Bytes()
@@ -418,20 +419,20 @@ func createControl(instSize int64, md5sums []byte, info *nfpm.Info) (controlTarG
 	}
 
 	if err := out.Close(); err != nil {
-		return nil, errors.Wrap(err, "closing control.tar.gz")
+		return nil, fmt.Errorf("closing control.tar.gz: %w", err)
 	}
 	if err := compress.Close(); err != nil {
-		return nil, errors.Wrap(err, "closing control.tar.gz")
+		return nil, fmt.Errorf("closing control.tar.gz: %w", err)
 	}
 	return buf.Bytes(), nil
 }
 
 func newItemInsideTarGz(out *tar.Writer, content []byte, header *tar.Header) error {
 	if err := out.WriteHeader(header); err != nil {
-		return errors.Wrapf(err, "cannot write header of %s file to control.tar.gz", header.Name)
+		return fmt.Errorf("cannot write header of %s file to control.tar.gz: %w", header.Name, err)
 	}
 	if _, err := out.Write(content); err != nil {
-		return errors.Wrapf(err, "cannot write %s file to control.tar.gz", header.Name)
+		return fmt.Errorf("cannot write %s file to control.tar.gz: %w", header.Name, err)
 	}
 	return nil
 }
@@ -490,7 +491,7 @@ func createTree(tarw *tar.Writer, dst string, created map[string]bool) error {
 			Format:   tar.FormatGNU,
 			ModTime:  time.Now(),
 		}); err != nil {
-			return errors.Wrap(err, "failed to create folder")
+			return fmt.Errorf("failed to create folder: %w", err)
 		}
 		created[path] = true
 	}

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -278,7 +278,7 @@ func TestDebFileDoesNotExist(t *testing.T) {
 		}),
 		ioutil.Discard,
 	)
-	assert.EqualError(t, err, "../testdata/whatever.confzzz: file does not exist")
+	assert.EqualError(t, err, "glob failed: ../testdata/whatever.confzzz: file does not exist")
 }
 
 func TestDebNoFiles(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/imdario/mergo v0.3.11
 	github.com/mattn/go-zglob v0.0.3
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/mattn/go-zglob"
-	"github.com/pkg/errors"
 )
 
 // longestCommonPrefix returns the longest prefix of all strings the argument
@@ -54,7 +53,7 @@ func (e ErrGlobNoMatch) Error() string {
 func Glob(glob, dst string) (map[string]string, error) {
 	matches, err := zglob.Glob(glob)
 	if err != nil {
-		return nil, errors.Wrap(err, glob)
+		return nil, fmt.Errorf("glob failed: %s: %w", glob, err)
 	}
 	if len(matches) == 0 {
 		return nil, ErrGlobNoMatch{glob}

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -50,7 +50,7 @@ func TestGlob(t *testing.T) {
 	assert.Equal(t, "/foo/bar/test_b.txt", singleFile["testdata/dir_a/dir_b/test_b.txt"])
 
 	nilvalue, err := Glob("does/not/exist", "/foo/bar")
-	assert.EqualError(t, err, "does/not/exist: file does not exist")
+	assert.EqualError(t, err, "glob failed: does/not/exist: file does not exist")
 	assert.Nil(t, nilvalue)
 
 	nomatches, err := Glob("testdata/nothing*", "/foo/bar")

--- a/internal/sign/rsa.go
+++ b/internal/sign/rsa.go
@@ -7,10 +7,10 @@ import (
 	"crypto/sha1" // nolint:gosec
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
-
-	"github.com/pkg/errors"
 )
 
 // RSASignSHA1Digest signs the provided SHA1 message digest. The key file
@@ -22,7 +22,7 @@ func RSASignSHA1Digest(sha1Digest []byte, keyFile, passphrase string) ([]byte, e
 
 	keyFileContent, err := ioutil.ReadFile(keyFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading key file")
+		return nil, fmt.Errorf("reading key file: %w", err)
 	}
 
 	block, _ := pem.Decode(keyFileContent)
@@ -40,7 +40,7 @@ func RSASignSHA1Digest(sha1Digest []byte, keyFile, passphrase string) ([]byte, e
 
 		decryptedBlockData, err = x509.DecryptPEMBlock(block, []byte(passphrase))
 		if err != nil {
-			return nil, errors.Wrap(err, "decrypt private key PEM block")
+			return nil, fmt.Errorf("decrypt private key PEM block: %w", err)
 		}
 
 		blockData = decryptedBlockData
@@ -48,12 +48,12 @@ func RSASignSHA1Digest(sha1Digest []byte, keyFile, passphrase string) ([]byte, e
 
 	priv, err := x509.ParsePKCS1PrivateKey(blockData)
 	if err != nil {
-		return nil, errors.Wrap(err, "parse PKCS1 private key")
+		return nil, fmt.Errorf("parse PKCS1 private key: %w", err)
 	}
 
 	signature, err := priv.Sign(rand.Reader, sha1Digest, crypto.SHA1)
 	if err != nil {
-		return nil, errors.Wrap(err, "signing")
+		return nil, fmt.Errorf("signing: %w", err)
 	}
 
 	return signature, nil
@@ -63,7 +63,7 @@ func rsaSign(message io.Reader, keyFile, passphrase string) ([]byte, error) {
 	sha256Hash := sha1.New() // nolint:gosec
 	_, err := io.Copy(sha256Hash, message)
 	if err != nil {
-		return nil, errors.Wrap(err, "create SHA256 message digest")
+		return nil, fmt.Errorf("create SHA256 message digest: %w", err)
 	}
 
 	return RSASignSHA1Digest(sha256Hash.Sum(nil), keyFile, passphrase)
@@ -78,7 +78,7 @@ func RSAVerifySHA1Digest(sha1Digest, signature []byte, publicKeyFile string) err
 
 	keyFileContent, err := ioutil.ReadFile(publicKeyFile)
 	if err != nil {
-		return errors.Wrap(err, "reading key file")
+		return fmt.Errorf("reading key file: %w", err)
 	}
 
 	block, _ := pem.Decode(keyFileContent)
@@ -88,17 +88,17 @@ func RSAVerifySHA1Digest(sha1Digest, signature []byte, publicKeyFile string) err
 
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		return errors.Wrap(err, "parse PKIX public key")
+		return fmt.Errorf("parse PKIX public key: %w", err)
 	}
 
 	rsaPub, ok := pub.(*rsa.PublicKey)
 	if !ok {
-		return errors.Wrap(err, "public key is no RSA key")
+		return fmt.Errorf("public key is no RSA key: %w", err)
 	}
 
 	err = rsa.VerifyPKCS1v15(rsaPub, crypto.SHA1, sha1Digest, signature)
 	if err != nil {
-		return errors.Wrap(err, "verify PKCS1v15 signature")
+		return fmt.Errorf("verify PKCS1v15 signature: %w", err)
 	}
 
 	return nil
@@ -108,7 +108,7 @@ func rsaVerify(message io.Reader, signature []byte, publicKeyFile string) error 
 	sha256Hash := sha1.New() // nolint:gosec
 	_, err := io.Copy(sha256Hash, message)
 	if err != nil {
-		return errors.Wrap(err, "create SHA1 message digest")
+		return fmt.Errorf("create SHA1 message digest: %w", err)
 	}
 
 	return RSAVerifySHA1Digest(sha256Hash.Sum(nil), signature, publicKeyFile)

--- a/nfpm.go
+++ b/nfpm.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/goreleaser/chglog"
 	"github.com/imdario/mergo"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -111,7 +110,7 @@ func (c *Config) Get(format string) (info *Info, err error) {
 	info = &Info{}
 	// make a deep copy of info
 	if err = mergo.Merge(info, c.Info); err != nil {
-		return nil, errors.Wrap(err, "failed to merge config into info")
+		return nil, fmt.Errorf("failed to merge config into info: %w", err)
 	}
 	override, ok := c.Overrides[format]
 	if !ok {
@@ -119,7 +118,7 @@ func (c *Config) Get(format string) (info *Info, err error) {
 		return info, nil
 	}
 	if err = mergo.Merge(&info.Overridables, override, mergo.WithOverride); err != nil {
-		return nil, errors.Wrap(err, "failed to merge overrides into info")
+		return nil, fmt.Errorf("failed to merge overrides into info: %w", err)
 	}
 	return info, nil
 }

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/google/rpmpack"
-	"github.com/pkg/errors"
 	"github.com/sassoftware/go-rpmutils/cpio"
 
 	"github.com/goreleaser/nfpm/internal/files"
@@ -370,7 +369,7 @@ func addSymlinksInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) {
 func copyToRPM(rpm *rpmpack.RPM, src, dst string, fileType rpmpack.FileType) error {
 	file, err := os.OpenFile(src, os.O_RDONLY, 0600) //nolint:gosec
 	if err != nil {
-		return errors.Wrap(err, "could not add file to the archive")
+		return fmt.Errorf("could not add file to the archive: %w", err)
 	}
 	// don't care if it errs while closing...
 	defer file.Close() // nolint: errcheck,gosec

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -340,7 +340,7 @@ func TestRPMFileDoesNotExist(t *testing.T) {
 		"../testdata/whatever.confzzz": "/etc/fake/fake.conf",
 	}
 	var err = Default.Package(info, ioutil.Discard)
-	assert.EqualError(t, err, "../testdata/whatever.confzzz: file does not exist")
+	assert.EqualError(t, err, "glob failed: ../testdata/whatever.confzzz: file does not exist")
 }
 
 func TestRPMMultiArch(t *testing.T) {


### PR DESCRIPTION
replace usages of `errors.Wrap` with `fmt.Errorf` using the new `%w` thing.