### PR TITLE
deps: Update zglob.

### DIFF
--- a/acceptance/testdata/rpm.meta.dockerfile
+++ b/acceptance/testdata/rpm.meta.dockerfile
@@ -1,6 +1,6 @@
 FROM fedora
 ARG package
 COPY ${package} /tmp/foo.rpm
-RUN yum install -y /tmp/foo.rpm
+RUN dnf install -y /tmp/foo.rpm
 RUN command -v zsh
 RUN command -v fish

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/rpmpack v0.0.0-20200919095143-1c1eea455332
 	github.com/goreleaser/chglog v0.1.1
 	github.com/imdario/mergo v0.3.11
-	github.com/mattn/go-zglob v0.0.3
+	github.com/mattn/go-zglob v0.0.4-0.20201013150311-602f75124917
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 // indirect
 	github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-zglob v0.0.3 h1:6Ry4EYsScDyt5di4OI6xw1bYhOqfE5S33Z1OPy+d+To=
-github.com/mattn/go-zglob v0.0.3/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
+github.com/mattn/go-zglob v0.0.4-0.20201013150311-602f75124917 h1:dYf27OGvVV8wGxrOg8lxJ+gE2IGWD7s6J3qvrze8w/k=
+github.com/mattn/go-zglob v0.0.4-0.20201013150311-602f75124917/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -56,6 +56,11 @@ func TestGlob(t *testing.T) {
 	nomatches, err := Glob("testdata/nothing*", "/foo/bar")
 	assert.Nil(t, nomatches)
 	assert.EqualError(t, err, "testdata/nothing*: no matching files")
+
+	escapedBrace, err := Glob("testdata/\\{dir_d\\}/*", "/foo/bar")
+	assert.NoError(t, err)
+	assert.Len(t, escapedBrace, 1)
+	assert.Equal(t, "/foo/bar/test_brace.txt", escapedBrace["testdata/{dir_d}/test_brace.txt"])
 }
 
 func TestSingleGlob(t *testing.T) {


### PR DESCRIPTION
This PR updates `go-zglob` to the first commit that supports escaping. This allows `nfpm` to package files that contain special glob characters such as `{` and `}`.