### PR TITLE
feat: add support for deb templates

### DIFF
--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -197,32 +197,12 @@ func TestControl(t *testing.T) {
 	assert.Equal(t, string(bts), w.String())
 }
 
-func TestScripts(t *testing.T) {
-	var w bytes.Buffer
-	var out = tar.NewWriter(&w)
-	filePath := "../testdata/scripts/preinstall.sh"
-	assert.Error(t, newScriptInsideTarGz(out, "doesnotexit", "preinst"))
-	require.NoError(t, newScriptInsideTarGz(out, filePath, "preinst"))
-	var in = tar.NewReader(&w)
-	header, err := in.Next()
-	require.NoError(t, err)
-	assert.Equal(t, "preinst", header.FileInfo().Name())
-	mode, err := strconv.ParseInt("0755", 8, 64)
-	require.NoError(t, err)
-	assert.Equal(t, int64(header.FileInfo().Mode()), mode)
-	data, err := ioutil.ReadAll(in)
-	require.NoError(t, err)
-	org, err := ioutil.ReadFile(filePath)
-	require.NoError(t, err)
-	assert.Equal(t, data, org)
-}
-
-func TestTemplates(t *testing.T) {
+func TestSpecialFiles(t *testing.T) {
 	var w bytes.Buffer
 	var out = tar.NewWriter(&w)
 	filePath := "testdata/templates.golden"
-	assert.Error(t, newFilePathInsideTarGz(out, "doesnotexit", "templates"))
-	require.NoError(t, newFilePathInsideTarGz(out, filePath, "templates"))
+	assert.Error(t, newFilePathInsideTarGz(out, "doesnotexit", "templates", 0644))
+	require.NoError(t, newFilePathInsideTarGz(out, filePath, "templates", 0644))
 	var in = tar.NewReader(&w)
 	header, err := in.Next()
 	require.NoError(t, err)

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -217,6 +217,26 @@ func TestScripts(t *testing.T) {
 	assert.Equal(t, data, org)
 }
 
+func TestTemplates(t *testing.T) {
+	var w bytes.Buffer
+	var out = tar.NewWriter(&w)
+	filePath := "testdata/templates.golden"
+	assert.Error(t, newFilePathInsideTarGz(out, "doesnotexit", "templates"))
+	require.NoError(t, newFilePathInsideTarGz(out, filePath, "templates"))
+	var in = tar.NewReader(&w)
+	header, err := in.Next()
+	require.NoError(t, err)
+	assert.Equal(t, "templates", header.FileInfo().Name())
+	mode, err := strconv.ParseInt("0644", 8, 64)
+	require.NoError(t, err)
+	assert.Equal(t, int64(header.FileInfo().Mode()), mode)
+	data, err := ioutil.ReadAll(in)
+	require.NoError(t, err)
+	org, err := ioutil.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, data, org)
+}
+
 func TestNoJoinsControl(t *testing.T) {
 	var w bytes.Buffer
 	assert.NoError(t, writeControl(&w, controlData{

--- a/deb/testdata/templates.golden
+++ b/deb/testdata/templates.golden
@@ -1,0 +1,4 @@
+Template: templates/lala
+Type: string
+Description: Set lala for templates.
+ For the test purpose this templates.golden is created.

--- a/nfpm.go
+++ b/nfpm.go
@@ -204,7 +204,6 @@ type APKSignature struct {
 // Deb is custom configs that are only available on deb packages.
 type Deb struct {
 	Scripts         DebScripts   `yaml:"scripts,omitempty"`
-	Templates       string       `yaml:"templates,omitempty"`
 	Triggers        DebTriggers  `yaml:"triggers,omitempty"`
 	Breaks          []string     `yaml:"breaks,omitempty"`
 	VersionMetadata string       `yaml:"metadata,omitempty"` // Deprecated: Moved to Info
@@ -233,7 +232,8 @@ type DebTriggers struct {
 
 // DebScripts is scripts only available on deb packages.
 type DebScripts struct {
-	Rules string `yaml:"rules,omitempty"`
+	Rules     string `yaml:"rules,omitempty"`
+	Templates string `yaml:"templates,omitempty"`
 }
 
 // Scripts contains information about maintainer scripts for packages.

--- a/nfpm.go
+++ b/nfpm.go
@@ -204,6 +204,7 @@ type APKSignature struct {
 // Deb is custom configs that are only available on deb packages.
 type Deb struct {
 	Scripts         DebScripts   `yaml:"scripts,omitempty"`
+	Templates       string       `yaml:"templates,omitempty"`
 	Triggers        DebTriggers  `yaml:"triggers,omitempty"`
 	Breaks          []string     `yaml:"breaks,omitempty"`
 	VersionMetadata string       `yaml:"metadata,omitempty"` // Deprecated: Moved to Info

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -152,11 +152,14 @@ rpm:
     # to #NFPM_PASSPHRASE.
     key_file: key.gpg
 
-# Custon configuration applied only to the Deb packager.
+# Custom configuration applied only to the Deb packager.
 deb:
-  # Custom deb rules script.
+  # Custom deb special files.
   scripts:
+    # Deb rules script.
     rules: foo.sh
+    # Deb templates file, when using debconf.
+    templates: templates
 
   # Custom deb triggers
   triggers:


### PR DESCRIPTION
Add support for `templates` file inside `DEBIAN` that is needed for `debconf` to be able to ask question user during installation. More on subject [here](http://www.fifi.org/doc/debconf-doc/tutorial.html) and [here](https://manpages.debian.org/testing/debconf-doc/debconf-devel.7.en.html)