### PR TITLE
feat: replace glob library

### DIFF
--- a/acceptance/testdata/complex.386.yaml
+++ b/acceptance/testdata/complex.386.yaml
@@ -19,7 +19,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 files:
   ../testdata/fake: "/usr/local/bin/fake"
-  ./testdata/folder/**/*: "/usr/share/whatever/folder/"
+  ./testdata/folder/*: "/usr/share/whatever/folder/"
 config_files:
   ../testdata/whatever.conf: "/etc/foo/whatever.conf"
 empty_folders:

--- a/acceptance/testdata/complex.yaml
+++ b/acceptance/testdata/complex.yaml
@@ -21,7 +21,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 files:
   ../testdata/fake: "/usr/local/bin/fake"
-  ./testdata/folder/**/*: "/usr/share/whatever/folder/"
+  ./testdata/folder/*: "/usr/share/whatever/folder/"
 config_files:
   ../testdata/whatever.conf: "/etc/foo/whatever.conf"
 empty_folders:

--- a/acceptance/testdata/overrides.yaml
+++ b/acceptance/testdata/overrides.yaml
@@ -19,7 +19,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 files:
   ../testdata/fake: "/usr/local/bin/fake"
-  ./testdata/folder/**/*: "/usr/share/whatever/folder/"
+  ./testdata/folder/*: "/usr/share/whatever/folder/"
 config_files:
   ../testdata/whatever.conf: "/etc/foo/whatever.conf"
 overrides:

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -168,7 +168,7 @@ func TestFileDoesNotExist(t *testing.T) {
 					"bash",
 				},
 				Files: map[string]string{
-					"../testdata/": "/usr/local/bin/fake",
+					"../testdata/fake": "/usr/local/bin/fake",
 				},
 				ConfigFiles: map[string]string{
 					"../testdata/whatever.confzzz": "/etc/fake/fake.conf",
@@ -177,7 +177,7 @@ func TestFileDoesNotExist(t *testing.T) {
 		}),
 		ioutil.Discard,
 	)
-	assert.EqualError(t, err, "glob failed: ../testdata/whatever.confzzz: file does not exist")
+	assert.EqualError(t, err, "glob failed: ../testdata/whatever.confzzz: no matching files")
 }
 
 func TestNoFiles(t *testing.T) {

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -269,7 +269,7 @@ func TestDebFileDoesNotExist(t *testing.T) {
 					"bash",
 				},
 				Files: map[string]string{
-					"../testdata/": "/usr/local/bin/fake",
+					"../testdata/fake": "/usr/local/bin/fake",
 				},
 				ConfigFiles: map[string]string{
 					"../testdata/whatever.confzzz": "/etc/fake/fake.conf",
@@ -278,7 +278,7 @@ func TestDebFileDoesNotExist(t *testing.T) {
 		}),
 		ioutil.Discard,
 	)
-	assert.EqualError(t, err, "glob failed: ../testdata/whatever.confzzz: file does not exist")
+	assert.EqualError(t, err, "glob failed: ../testdata/whatever.confzzz: no matching files")
 }
 
 func TestDebNoFiles(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
+	github.com/gobwas/glob v0.2.3
 	github.com/golangci/golangci-lint v1.31.0
 	github.com/google/rpmpack v0.0.0-20200919095143-1c1eea455332
 	github.com/goreleaser/chglog v0.1.1
 	github.com/imdario/mergo v0.3.11
-	github.com/mattn/go-zglob v0.0.4-0.20201013150311-602f75124917
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 // indirect
 	github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golangci/golangci-lint v1.31.0
 	github.com/google/rpmpack v0.0.0-20200919095143-1c1eea455332
 	github.com/goreleaser/chglog v0.1.1
-	github.com/goreleaser/fileglob v0.1.0
+	github.com/goreleaser/fileglob v0.2.1
 	github.com/imdario/mergo v0.3.11
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 // indirect
 	github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
-	github.com/gobwas/glob v0.2.3
 	github.com/golangci/golangci-lint v1.31.0
 	github.com/google/rpmpack v0.0.0-20200919095143-1c1eea455332
 	github.com/goreleaser/chglog v0.1.1
+	github.com/goreleaser/fileglob v0.1.0
 	github.com/imdario/mergo v0.3.11
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 // indirect
 	github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,6 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-zglob v0.0.4-0.20201013150311-602f75124917 h1:dYf27OGvVV8wGxrOg8lxJ+gE2IGWD7s6J3qvrze8w/k=
-github.com/mattn/go-zglob v0.0.4-0.20201013150311-602f75124917/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/goreleaser/chglog v0.1.1 h1:UaY3enMEVeavOaZyCraLn+2iM7/2T0yji8Mh7ZFsDp4=
 github.com/goreleaser/chglog v0.1.1/go.mod h1:xSDa/73C0TxBcLvoT2JHh47QyXpCx5rrNVzJKyeFGPw=
+github.com/goreleaser/fileglob v0.1.0 h1:SuQWRsmFhnHOzqjDrWF+/3zYYxV0G8iDJ3c8Eo1kJsY=
+github.com/goreleaser/fileglob v0.1.0/go.mod h1:N/C1IgdTAy77Whwd1PS+uNBLit0RBnL89nKbTnYljhk=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
@@ -406,6 +408,8 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.2 h1:GDarE4TJQI52kYSbSAmLiId1Elfj+xgSDqrUZxFhxlU=
 github.com/spf13/afero v1.3.2/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
+github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
+github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/goreleaser/chglog v0.1.1 h1:UaY3enMEVeavOaZyCraLn+2iM7/2T0yji8Mh7ZFsDp4=
 github.com/goreleaser/chglog v0.1.1/go.mod h1:xSDa/73C0TxBcLvoT2JHh47QyXpCx5rrNVzJKyeFGPw=
-github.com/goreleaser/fileglob v0.1.0 h1:SuQWRsmFhnHOzqjDrWF+/3zYYxV0G8iDJ3c8Eo1kJsY=
-github.com/goreleaser/fileglob v0.1.0/go.mod h1:N/C1IgdTAy77Whwd1PS+uNBLit0RBnL89nKbTnYljhk=
+github.com/goreleaser/fileglob v0.2.1 h1:tnKYHrWm00afuZpyEKGzgHWCaEExeT7jiwdVOTbKNXk=
+github.com/goreleaser/fileglob v0.2.1/go.mod h1:kNcPrPzjCp+Ox3jmXLU5QEsjhqrtLBm6OnXAif8KRl8=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -15,7 +15,7 @@ func TestListFilesToCopy(t *testing.T) {
 				"../../testdata/whatever.conf": "/whatever",
 			},
 			Files: map[string]string{
-				"../../testdata/scripts/**/*": "/test",
+				"../../testdata/scripts/*": "/test",
 			},
 		},
 	}

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -51,7 +51,7 @@ func (e ErrGlobNoMatch) Error() string {
 // First the longest common prefix (lcp) of all globbed files is found. The destination
 // for each globbed file is then dst joined with src with the lcp trimmed off.
 func Glob(pattern, dst string) (map[string]string, error) {
-	g, err := glob.Compile(pattern)
+	g, err := glob.Compile(strings.TrimPrefix(pattern, "./"), '/')
 	if err != nil {
 		return nil, fmt.Errorf("glob failed: %s: %w", pattern, err)
 	}

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -44,7 +44,7 @@ type ErrGlobNoMatch struct {
 }
 
 func (e ErrGlobNoMatch) Error() string {
-	return fmt.Sprintf("%s: no matching files", e.glob)
+	return fmt.Sprintf("glob failed: %s: no matching files", e.glob)
 }
 
 // Glob returns a map with source file path as keys and destination as values.

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gobwas/glob"
+	"github.com/goreleaser/fileglob"
 )
 
 // longestCommonPrefix returns the longest prefix of all strings the argument
@@ -51,18 +51,9 @@ func (e ErrGlobNoMatch) Error() string {
 // First the longest common prefix (lcp) of all globbed files is found. The destination
 // for each globbed file is then dst joined with src with the lcp trimmed off.
 func Glob(pattern, dst string) (map[string]string, error) {
-	g, err := glob.Compile(strings.TrimPrefix(pattern, "./"), '/')
+	matches, err := fileglob.Glob(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("glob failed: %s: %w", pattern, err)
-	}
-	var matches []string
-	if err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-		if g.Match(path) {
-			matches = append(matches, path)
-		}
-		return nil
-	}); err != nil {
-		return nil, err
 	}
 
 	if len(matches) == 0 {

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -3,7 +3,7 @@ package glob
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLongestCommonPrefix(t *testing.T) {
@@ -17,11 +17,11 @@ func TestLongestCommonPrefix(t *testing.T) {
 	}
 
 	lcp1 := longestCommonPrefix(strings)
-	assert.Equal(t, "long", lcp1)
+	require.Equal(t, "long", lcp1)
 
 	empty := []string{}
 	lcp2 := longestCommonPrefix(empty)
-	assert.Equal(t, "", lcp2)
+	require.Equal(t, "", lcp2)
 
 	unique := []string{
 		"every",
@@ -34,38 +34,55 @@ func TestLongestCommonPrefix(t *testing.T) {
 	}
 
 	lcp3 := longestCommonPrefix(unique)
-	assert.Equal(t, "", lcp3)
+	require.Equal(t, "", lcp3)
 }
 
 func TestGlob(t *testing.T) {
-	files, err := Glob("testdata/dir_a/dir_*/*", "/foo/bar")
-	assert.NoError(t, err)
-	assert.Len(t, files, 2)
-	assert.Equal(t, "/foo/bar/dir_b/test_b.txt", files["testdata/dir_a/dir_b/test_b.txt"])
-	assert.Equal(t, "/foo/bar/dir_c/test_c.txt", files["testdata/dir_a/dir_c/test_c.txt"])
+	t.Run("simple", func(t *testing.T) {
+		files, err := Glob("./testdata/dir_a/dir_*/*", "/foo/bar")
+		require.NoError(t, err)
+		require.Len(t, files, 2)
+		require.Equal(t, "/foo/bar/dir_b/test_b.txt", files["testdata/dir_a/dir_b/test_b.txt"])
+		require.Equal(t, "/foo/bar/dir_c/test_c.txt", files["testdata/dir_a/dir_c/test_c.txt"])
+	})
 
-	singleFile, err := Glob("testdata/dir_a/dir_b/*", "/foo/bar")
-	assert.NoError(t, err)
-	assert.Len(t, singleFile, 1)
-	assert.Equal(t, "/foo/bar/test_b.txt", singleFile["testdata/dir_a/dir_b/test_b.txt"])
+	t.Run("single file", func(t *testing.T) {
+		files, err := Glob("testdata/dir_a/dir_b/*", "/foo/bar")
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		require.Equal(t, "/foo/bar/test_b.txt", files["testdata/dir_a/dir_b/test_b.txt"])
+	})
 
-	nilvalue, err := Glob("does/not/exist", "/foo/bar")
-	assert.EqualError(t, err, "does/not/exist: no matching files")
-	assert.Nil(t, nilvalue)
+	t.Run("double star", func(t *testing.T) {
+		files, err := Glob("testdata/**/test*.txt", "/foo/bar")
+		require.NoError(t, err)
+		require.Len(t, files, 3)
+		require.Equal(t, "/foo/bar/dir_a/dir_b/test_b.txt", files["testdata/dir_a/dir_b/test_b.txt"])
+	})
 
-	nomatches, err := Glob("testdata/nothing*", "/foo/bar")
-	assert.Nil(t, nomatches)
-	assert.EqualError(t, err, "testdata/nothing*: no matching files")
+	t.Run("nil value", func(t *testing.T) {
+		files, err := Glob("does/not/exist", "/foo/bar")
+		require.EqualError(t, err, "does/not/exist: no matching files")
+		require.Nil(t, files)
+	})
 
-	escapedBrace, err := Glob("testdata/\\{dir_d\\}/*", "/foo/bar")
-	assert.NoError(t, err)
-	assert.Len(t, escapedBrace, 1)
-	assert.Equal(t, "/foo/bar/test_brace.txt", escapedBrace["testdata/{dir_d}/test_brace.txt"])
-}
+	t.Run("no matches", func(t *testing.T) {
+		files, err := Glob("testdata/nothing*", "/foo/bar")
+		require.Nil(t, files)
+		require.EqualError(t, err, "testdata/nothing*: no matching files")
+	})
 
-func TestSingleGlob(t *testing.T) {
-	files, err := Glob("testdata/dir_a/dir_b/test_b.txt", "/foo/bar/dest.dat")
-	assert.NoError(t, err)
-	assert.Len(t, files, 1)
-	assert.Equal(t, "/foo/bar/dest.dat", files["testdata/dir_a/dir_b/test_b.txt"])
+	t.Run("escaped brace", func(t *testing.T) {
+		files, err := Glob("testdata/\\{dir_d\\}/*", "/foo/bar")
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		require.Equal(t, "/foo/bar/test_brace.txt", files["testdata/{dir_d}/test_brace.txt"])
+	})
+
+	t.Run("no glob", func(t *testing.T) {
+		files, err := Glob("testdata/dir_a/dir_b/test_b.txt", "/foo/bar/dest.dat")
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		require.Equal(t, "/foo/bar/dest.dat", files["testdata/dir_a/dir_b/test_b.txt"])
+	})
 }

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -62,14 +62,14 @@ func TestGlob(t *testing.T) {
 
 	t.Run("nil value", func(t *testing.T) {
 		files, err := Glob("does/not/exist", "/foo/bar")
-		require.EqualError(t, err, "does/not/exist: no matching files")
+		require.EqualError(t, err, "glob failed: does/not/exist: no matching files")
 		require.Nil(t, files)
 	})
 
 	t.Run("no matches", func(t *testing.T) {
 		files, err := Glob("testdata/nothing*", "/foo/bar")
 		require.Nil(t, files)
-		require.EqualError(t, err, "testdata/nothing*: no matching files")
+		require.EqualError(t, err, "glob failed: testdata/nothing*: no matching files")
 	})
 
 	t.Run("escaped brace", func(t *testing.T) {

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -50,7 +50,7 @@ func TestGlob(t *testing.T) {
 	assert.Equal(t, "/foo/bar/test_b.txt", singleFile["testdata/dir_a/dir_b/test_b.txt"])
 
 	nilvalue, err := Glob("does/not/exist", "/foo/bar")
-	assert.EqualError(t, err, "glob failed: does/not/exist: file does not exist")
+	assert.EqualError(t, err, "does/not/exist: no matching files")
 	assert.Nil(t, nilvalue)
 
 	nomatches, err := Glob("testdata/nothing*", "/foo/bar")

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -334,13 +334,13 @@ echo "Postremove" > /dev/null
 func TestRPMFileDoesNotExist(t *testing.T) {
 	info := exampleInfo()
 	info.Files = map[string]string{
-		"../testdata/": "/usr/local/bin/fake",
+		"../testdata/fake": "/usr/local/bin/fake",
 	}
 	info.ConfigFiles = map[string]string{
 		"../testdata/whatever.confzzz": "/etc/fake/fake.conf",
 	}
 	var err = Default.Package(info, ioutil.Discard)
-	assert.EqualError(t, err, "glob failed: ../testdata/whatever.confzzz: file does not exist")
+	assert.EqualError(t, err, "glob failed: ../testdata/whatever.confzzz: no matching files")
 }
 
 func TestRPMMultiArch(t *testing.T) {


### PR DESCRIPTION
BREAKING CHANGE: may have unintended side-effects.

closes #232

error message when no files match a glog changed, because now its handled in another place... but seems like tests are still passing...