### PR TITLE
feat: Support RPM ghost files

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -182,6 +182,7 @@ type RPM struct {
 	// https://www.cl.cam.ac.uk/~jw35/docs/rpm_config.html
 	ConfigNoReplaceFiles map[string]string `yaml:"config_noreplace_files,omitempty"`
 	Signature            RPMSignature      `yaml:"signature,omitempty"`
+	GhostFiles           []string          `yaml:"ghost_files,omitempty"`
 }
 
 type RPMSignature struct {

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -350,6 +350,19 @@ func createFilesInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) error {
 		}
 	}
 
+	// note: the ghost files will be created as empty files when the package is installed, which is not
+	// correct: https://github.com/google/rpmpack/issues/51
+	for _, destName := range info.RPM.GhostFiles {
+		rpm.AddFile(rpmpack.RPMFile{
+			Name:  destName,
+			Mode:  0644,
+			MTime: uint32(time.Now().UTC().Unix()),
+			Owner: "root",
+			Group: "root",
+			Type:  rpmpack.GhostFile,
+		})
+	}
+
 	return nil
 }
 

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -131,7 +131,7 @@ overrides:
   apk:
     # ...
 
-# Custon configuration applied only to the RPM packager.
+# Custom configuration applied only to the RPM packager.
 rpm:
   # The package group. This option is deprecated by most distros
   # but required by old distros like CentOS 5 / EL 5 and earlier.
@@ -148,6 +148,20 @@ rpm:
   # changed by the user. Corresponds to %config(noreplace).
   config_noreplace_files:
     path/to/local/bar.con: /etc/bar.conf
+
+  # These files are not actually present in the package, but the file names
+  # are added to the package header. From the RPM directives documentation:
+  #
+  # "There are times when a file should be owned by the package but not
+  # installed - log files and state files are good examples of cases you might
+  # desire this to happen."
+  #
+  # "The way to achieve this, is to use the %ghost directive. By adding this
+  # directive to the line containing a file, RPM will know about the ghosted
+  # file, but will not add it to the package."
+  ghost_files:
+    - /etc/casper.conf
+    - /var/log/boo.log
 
   # The package is signed if a key_file is set
   signature:


### PR DESCRIPTION
From the [Maximum RPM] guide:

    The %ghost Directive

    As we mentioned in the Section called The %files List, if a file
    is specified in the %files list, that file will automatically be
    included in the package. There are times when a file should be
    owned by the package but not installed - log files and state files
    are good examples of cases you might desire this to happen.

    The way to achieve this, is to use the %ghost directive. By adding
    this directive to the line containing a file, RPM will know about
    the ghosted file, but will not add it to the package.

Ghost files are specified using `Type: rpmpack.GhostFile` when
constructing the output package.

The test ensures that we have:
 - The target file present in the RPM.
 - The specified mode attributes (although not really important,
 either).
 - An empty file *[1]* in the RPM for the named ghost, 
see [google/rpmpack #51].

*[1] Instead of an empty file, no file should be created, but this is
not possible until the upstream issue is resolved.*

[Maximum RPM]:
http://ftp.rpm.org/max-rpm/s1-rpm-inside-files-list-directives.html

[google/rpmpack #51]: https://github.com/google/rpmpack/issues/51