### PR TITLE
feat: Allow explicit summary from RPM packages

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -177,6 +177,7 @@ type Overridables struct {
 // RPM is custom configs that are only available on RPM packages.
 type RPM struct {
 	Group       string `yaml:"group,omitempty"`
+	Summary     string `yaml:"summary,omitempty"`
 	Compression string `yaml:"compression,omitempty"`
 	// https://www.cl.cam.ac.uk/~jw35/docs/rpm_config.html
 	ConfigNoReplaceFiles map[string]string `yaml:"config_noreplace_files,omitempty"`

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -207,7 +207,7 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 
 	return &rpmpack.RPMMetaData{
 		Name:        info.Name,
-		Summary:     strings.Split(info.Description, "\n")[0],
+		Summary:     defaultTo(info.RPM.Summary, strings.Split(info.Description, "\n")[0]),
 		Description: info.Description,
 		Version:     formatVersion(info),
 		Release:     defaultTo(info.Release, "1"),

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -141,6 +141,31 @@ func TestRPMGroup(t *testing.T) {
 	assert.Equal(t, "Unspecified", group)
 }
 
+func TestRPMSummary(t *testing.T) {
+	f, err := ioutil.TempFile("", "test.rpm")
+	defer func() {
+		_ = f.Close()
+		err = os.Remove(f.Name())
+		assert.NoError(t, err)
+	}()
+
+	var customSummary = "This is my custom summary"
+	info := exampleInfo()
+	info.RPM.Group = "Unspecified"
+	info.RPM.Summary = customSummary
+
+	require.NoError(t, Default.Package(info, f))
+
+	file, err := os.OpenFile(f.Name(), os.O_RDONLY, 0600) //nolint:gosec
+	require.NoError(t, err)
+	rpm, err := rpmutils.ReadRpm(file)
+	require.NoError(t, err)
+
+	summary, err := rpm.Header.GetString(rpmutils.SUMMARY)
+	require.NoError(t, err)
+	assert.Equal(t, customSummary, summary)
+}
+
 func TestWithRPMTags(t *testing.T) {
 	f, err := ioutil.TempFile("", "test.rpm")
 	defer func() {

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -137,6 +137,10 @@ rpm:
   # but required by old distros like CentOS 5 / EL 5 and earlier.
   group: Unspecified
 
+  # The package summary. This is, by default, the first line of the
+  # description, but can be explicitly provided here.
+  summary: Explicit Summary for Sample Package
+
   # Compression algorithm.
   compression: lzma
 


### PR DESCRIPTION
The previous behaviour was to use only the first line of the
description as the summary. In some cases, it is desirable to have a
separate summary. Since only RPM packages have a summary field, I've
put this inside the RPM configuration.

    description: This is my description
    rpm:
      summary: This is my summary

By default, just use the first line of the description.