### PR TITLE
fix: allow using an env var in the signature.key_file field

### DIFF
--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -153,9 +153,17 @@ func TestParseFile(t *testing.T) {
 	require.NoError(t, err)
 	_, err = nfpm.ParseFile("./testdata/doesnotexist.yaml")
 	require.Error(t, err)
-	config, err := nfpm.ParseFile("./testdata/versionenv.yaml")
+	os.Setenv("RPM_KEY_FILE", "my/rpm/key/file")
+	os.Setenv("TEST_RELEASE_ENV_VAR", "1234")
+	os.Setenv("TEST_PRERELEASE_ENV_VAR", "beta1")
+	config, err := nfpm.ParseFile("./testdata/env-fields.yaml")
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("v%s", os.Getenv("GOROOT")), config.Version)
+	require.Equal(t, "1234", config.Release)
+	require.Equal(t, "beta1", config.Prerelease)
+	require.Equal(t, "my/rpm/key/file", config.RPM.Signature.KeyFile)
+	require.Equal(t, "hard/coded/file", config.Deb.Signature.KeyFile)
+	require.Equal(t, "", config.APK.Signature.KeyFile)
 }
 
 func TestParseEnhancedFile(t *testing.T) {

--- a/testdata/env-fields.yaml
+++ b/testdata/env-fields.yaml
@@ -2,6 +2,8 @@
 name: "foo"
 arch: "amd64"
 version: "v$GOROOT"
+release: ${TEST_RELEASE_ENV_VAR}
+prerelease: ${TEST_PRERELEASE_ENV_VAR}
 contents:
 - src: ./testdata/whatever.conf
   dst: /etc/foo/regular.conf
@@ -14,6 +16,15 @@ contents:
   dst: /rpm/path
   type: config
   packager: rpm
+rpm:
+  signature:
+    key_file: ${RPM_KEY_FILE}
+deb:
+  signature:
+    key_file: hard/coded/file
+apk:
+  signature:
+    key_file: ${NO_ENV_VAR_SET_SO_SHOULD_BE_EMPTY}
 overrides:
   deb:
     depends:

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -16,6 +16,7 @@ arch: amd64
 platform: linux
 
 # Version. (required)
+# This will expand any env var you set in the field, eg version: v${SEMVER}
 version: v1.2.3
 
 # Version Epoch.
@@ -32,6 +33,7 @@ prerelease: beta1
 version_metadata: git
 
 # Version Release.
+# This will expand any env var you set in the field, eg release: ${VERSION_RELEASE}
 release: 1
 
 # Section.
@@ -197,6 +199,7 @@ rpm:
     # PGP secret key (can also be ASCII-armored), the passphrase is taken
     # from the environment variable $NFPM_RPM_PASSPHRASE with a fallback
     # to #NFPM_PASSPHRASE.
+    # This will expand any env var you set in the field, eg key_file: ${SIGNING_KEY_FILE}
     key_file: key.gpg
 
 # Custom configuration applied only to the Deb packager.
@@ -230,6 +233,7 @@ deb:
     # PGP secret key (can also be ASCII-armored). The passphrase is taken
     # from the environment variable $NFPM_DEB_PASSPHRASE with a fallback
     # to #NFPM_PASSPHRASE.
+    # This will expand any env var you set in the field, eg key_file: ${SIGNING_KEY_FILE}
     key_file: key.gpg
     # The type describes the signers role, possible values are "origin",
     # "maint" and "archive". If unset, the type defaults to "origin".
@@ -241,6 +245,7 @@ apk:
     # RSA private key in the PEM format. The passphrase is taken from
     # the environment variable $NFPM_APK_PASSPHRASE with a fallback
     # to #NFPM_PASSPHRASE.
+    # This will expand any env var you set in the field, eg key_file: ${SIGNING_KEY_FILE}
     key_file: key.gpg
     # The name of the signing key. When verifying a package, the signature
     # is matched to the public key store in /etc/apk/keys/<key_name>.rsa.pub.


### PR DESCRIPTION
I want to use the same config file for local builds that are not signed and pipeline builds that are signed so I need to be able to specify the key_file as an env var.