### PR TITLE
fix: set the alpine linux version to v3.12 so the acceptance tests pass

### DIFF
--- a/testdata/acceptance/apk.386.complex.dockerfile
+++ b/testdata/acceptance/apk.386.complex.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.386.dockerfile
+++ b/testdata/acceptance/apk.386.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.arm64.dockerfile
+++ b/testdata/acceptance/apk.arm64.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.changelog.dockerfile
+++ b/testdata/acceptance/apk.changelog.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.complex.dockerfile
+++ b/testdata/acceptance/apk.complex.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.dockerfile
+++ b/testdata/acceptance/apk.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.env-var-version.dockerfile
+++ b/testdata/acceptance/apk.env-var-version.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.meta.dockerfile
+++ b/testdata/acceptance/apk.meta.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.min.dockerfile
+++ b/testdata/acceptance/apk.min.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.overrides.dockerfile
+++ b/testdata/acceptance/apk.overrides.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add -vvv --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.ppc64le.dockerfile
+++ b/testdata/acceptance/apk.ppc64le.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk

--- a/testdata/acceptance/apk.signed.dockerfile
+++ b/testdata/acceptance/apk.signed.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY keys/rsa_unprotected.pub /etc/apk/keys/john@example.com.rsa.pub
 COPY ${package} /tmp/foo.apk

--- a/testdata/acceptance/apk.symlink.dockerfile
+++ b/testdata/acceptance/apk.symlink.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 ARG package
 COPY ${package} /tmp/foo.apk
 RUN apk add --allow-untrusted /tmp/foo.apk


### PR DESCRIPTION
I will create another issue to track the requirement that we start embedding the checksums in the apk files.