### PR TITLE
fix: Prevent destination collisions

### DIFF
--- a/files/files_test.go
+++ b/files/files_test.go
@@ -62,3 +62,13 @@ contents:
 	}
 	wg.Wait()
 }
+
+func TestCollision(t *testing.T) {
+	configuredFiles := []*files.Content{
+		{Source: "../testdata/whatever.conf", Destination: "/samedestination"},
+		{Source: "../testdata/whatever2.conf", Destination: "/samedestination"},
+	}
+
+	_, err := files.ExpandContentGlobs(configuredFiles, true)
+	require.ErrorIs(t, err, files.ErrContentCollision)
+}

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -100,10 +100,17 @@ contents:
     dst: /etc/foo.conf
     type: config
 
-  # Simple symlink
-  #	Will result in `ln -s /sbin/foo /usr/local/bin/foo`.
-  - src: /sbin/foo
-    dst: /usr/local/bin/foo
+  # Simple symlink at /usr/local/bin/foo which points to /sbin/foo, which is
+  # the same behaviour as `ln -s /sbin/foo /usr/local/bin/foo`.
+  #
+  # This also means that both "src" and "dst" are paths inside the package (or
+  # rather paths in the file system where the package will be installed) and
+  # not in the build environment. This is different from regular files where
+  # "src" is a path in the build environment. However, this convention results
+  # in "dst" always being the file that is created when installing the
+  # package.
+  - src: /actual/path/to/foo
+    dst: /usr/bin/foo
     type: symlink
 
   # Corresponds to `%config(noreplace)` if the packager is rpm, otherwise it is just a config file


### PR DESCRIPTION
This PR makes `ExpandContentGlobs` return an error when multiple contents share the same destination. Otherwise, the destination would just be overwritten.

This leads to particularly nasty broken packages when the symlink convention is misunderstood, so I improved the documentation for that too. If you think that doesn't belong in this PR I will split the PR. But first hear me out:

Everyone I know (including myself) always forgets the order of arguments in `ln -s file1 file2` such that most of the time `ln` calls are preceded by `man ln`. So refering to `ln` in the `nfpm` docs for symlinks might not be the best idea. I learned this the hard way when I added a symlink to a package thinking that

```
- src: /usr/bin/mybinary
  dst: /path/to/my/actual/binary
  type: symlink
```

means that I create a symlink that points from the source ` /usr/bin/mybinary` to the destination `/path/to/my/actual/binary`, but actually it is the other way around. That is definitely confusing but ultimately not a bad idea because this way "dst" always refers to the file created by the package. So this just needed more documentation.

But the end of the story was that my package resulted in a dangling symlink at `/path/to/my/actual/binary` which completely overwrote the actual binary 😄. So this PR addresses both issues that together lead to this broken result.