### PR TITLE
fix: apk checksums

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -396,10 +396,10 @@ func newItemInsideTarGz(out *tar.Writer, content []byte, header *tar.Header) err
 		header.PAXRecords[fmt.Sprintf("APK-TOOLS.checksum.%s", name)] = fmt.Sprintf("%x", hash.Sum(content))
 	}
 	if err := out.WriteHeader(header); err != nil {
-		return fmt.Errorf("cannot write header of %s file to control.tar.gz: %w", header.Name, err)
+		return fmt.Errorf("cannot write header of %s file to apk: %w", header.Name, err)
 	}
 	if _, err := out.Write(content); err != nil {
-		return fmt.Errorf("cannot write %s file to control.tar.gz: %w", header.Name, err)
+		return fmt.Errorf("cannot write %s file to apk: %w", header.Name, err)
 	}
 	return nil
 }

--- a/apk/apk.go
+++ b/apk/apk.go
@@ -31,10 +31,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto"
-	_ "crypto/md5"
 	_ "crypto/sha1" // nolint:gosec
-	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -72,13 +69,6 @@ var archToAlpine = map[string]string{
 	"arm64": "aarch64",
 
 	// "s390x":  "???",
-}
-
-var supportedChecksumHash = map[crypto.Hash]string{
-	crypto.MD5:    "MD5",
-	crypto.SHA1:   "SHA1",
-	crypto.SHA256: "SHA256",
-	crypto.SHA512: "SHA512",
 }
 
 // Default apk packager.
@@ -388,13 +378,12 @@ func newItemInsideTarGz(out *tar.Writer, content []byte, header *tar.Header) err
 	header.Format = tar.FormatPAX
 	header.PAXRecords = make(map[string]string)
 
-	for hasher, name := range supportedChecksumHash {
-		if !hasher.Available() {
-			continue
-		}
-		hash := hasher.New()
-		header.PAXRecords[fmt.Sprintf("APK-TOOLS.checksum.%s", name)] = fmt.Sprintf("%x", hash.Sum(content))
+	hasher := crypto.SHA1.New()
+	_, err := hasher.Write(content)
+	if err!=nil{
+		return fmt.Errorf("failed to hash content of file %s: %w", header.Name, err)
 	}
+	header.PAXRecords["APK-TOOLS.checksum.SHA1"] = fmt.Sprintf("%x", hasher.Sum(nil))
 	if err := out.WriteHeader(header); err != nil {
 		return fmt.Errorf("cannot write header of %s file to apk: %w", header.Name, err)
 	}

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -149,24 +149,15 @@ func TestPathsToCreate(t *testing.T) {
 func TestDefaultWithArch(t *testing.T) {
 	expectedPaxRecords := map[string]map[string]string{
 		"usr/share/doc/fake/fake.txt": {
-			"APK-TOOLS.checksum.MD5":    "666f6f3d6261720ad41d8cd98f00b204e9800998ecf8427e",
-			"APK-TOOLS.checksum.SHA1":   "666f6f3d6261720ada39a3ee5e6b4b0d3255bfef95601890afd80709",
-			"APK-TOOLS.checksum.SHA256": "666f6f3d6261720ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			"APK-TOOLS.checksum.SHA512": "666f6f3d6261720acf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+			"APK-TOOLS.checksum.SHA1":   "96c335dc28122b5f09a4cef74b156cd24c23784c",
 			"mtime":                     "1551704668.328",
 		},
 		"usr/local/bin/fake": {
-			"APK-TOOLS.checksum.MD5":    "6563686f20746573740ad41d8cd98f00b204e9800998ecf8427e",
-			"APK-TOOLS.checksum.SHA1":   "6563686f20746573740ada39a3ee5e6b4b0d3255bfef95601890afd80709",
-			"APK-TOOLS.checksum.SHA256": "6563686f20746573740ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			"APK-TOOLS.checksum.SHA512": "6563686f20746573740acf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+			"APK-TOOLS.checksum.SHA1":   "f46cece3eeb7d9ed5cb244d902775427be71492d",
 			"mtime":                     "1597696911.186869419",
 		},
 		"etc/fake/fake.conf": {
-			"APK-TOOLS.checksum.MD5":    "666f6f3d6261720ad41d8cd98f00b204e9800998ecf8427e",
-			"APK-TOOLS.checksum.SHA1":   "666f6f3d6261720ada39a3ee5e6b4b0d3255bfef95601890afd80709",
-			"APK-TOOLS.checksum.SHA256": "666f6f3d6261720ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-			"APK-TOOLS.checksum.SHA512": "666f6f3d6261720acf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+			"APK-TOOLS.checksum.SHA1":   "96c335dc28122b5f09a4cef74b156cd24c23784c",
 			"mtime":                     "1551704668.328",
 		},
 	}

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -147,19 +147,10 @@ func TestPathsToCreate(t *testing.T) {
 }
 
 func TestDefaultWithArch(t *testing.T) {
-	expectedPaxRecords := map[string]map[string]string{
-		"usr/share/doc/fake/fake.txt": {
-			"APK-TOOLS.checksum.SHA1":   "96c335dc28122b5f09a4cef74b156cd24c23784c",
-			"mtime":                     "1551704668.328",
-		},
-		"usr/local/bin/fake": {
-			"APK-TOOLS.checksum.SHA1":   "f46cece3eeb7d9ed5cb244d902775427be71492d",
-			"mtime":                     "1597696911.186869419",
-		},
-		"etc/fake/fake.conf": {
-			"APK-TOOLS.checksum.SHA1":   "96c335dc28122b5f09a4cef74b156cd24c23784c",
-			"mtime":                     "1551704668.328",
-		},
+	expectedChecksums := map[string]string{
+		"usr/share/doc/fake/fake.txt": "96c335dc28122b5f09a4cef74b156cd24c23784c",
+		"usr/local/bin/fake":          "f46cece3eeb7d9ed5cb244d902775427be71492d",
+		"etc/fake/fake.conf":          "96c335dc28122b5f09a4cef74b156cd24c23784c",
 	}
 	for _, arch := range []string{"386", "amd64"} {
 		arch := arch
@@ -182,7 +173,7 @@ func TestDefaultWithArch(t *testing.T) {
 				}
 				require.NoError(t, err)
 
-				require.Equal(t, expectedPaxRecords[hdr.Name], hdr.PAXRecords, hdr.Name)
+				require.Equal(t, expectedChecksums[hdr.Name], hdr.PAXRecords["APK-TOOLS.checksum.SHA1"], hdr.Name)
 			}
 		})
 	}

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,7 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/goreleaser/chglog v0.1.2 h1:tdzAb/ILeMnphzI9zQ7Nkq+T8R9qyXli8GydD8plFRY=
 github.com/goreleaser/chglog v0.1.2/go.mod h1:tTZsFuSZK4epDXfjMkxzcGbrIOXprf0JFp47BjIr3B8=
-github.com/goreleaser/fileglob v0.3.1 h1:OTFDWqUUHjQazk2N5GdUqEbqT/grBnRARaAXsV07q1Y=
-github.com/goreleaser/fileglob v0.3.1/go.mod h1:kNcPrPzjCp+Ox3jmXLU5QEsjhqrtLBm6OnXAif8KRl8=
+github.com/goreleaser/fileglob v0.4.0 h1:bZfPopbWScZi0MrsV+9YcJ0dN8w5OV4OwjDzrHI1Zyw=
 github.com/goreleaser/fileglob v0.4.0/go.mod h1:kNcPrPzjCp+Ox3jmXLU5QEsjhqrtLBm6OnXAif8KRl8=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=


### PR DESCRIPTION
- looking at official packages, seems like only SHA1 is needed (made a small thing to check that: https://github.com/caarlos0/apkcat)
- added tests
- fixed the missing write to the hasher function

The packages actually had the file contents as a header as well as far as I understand. 

PS: tested it with goreleaser itself as well.

Refs https://github.com/goreleaser/nfpm/commit/3b7e01508a19a2fa6e2ebb1b4685dd4e3cbfd785
refs #291