### PR TITLE
fix: Fix file collision detection with per-file packagers

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -180,7 +180,8 @@ func appendWithUniqueDestination(slice []*Content, elems ...*Content) ([]*Conten
 	}
 
 	for _, elem := range elems {
-		if present, ok := alreadyPresent[elem.Destination]; ok {
+		present, ok := alreadyPresent[elem.Destination]
+		if ok && (present.Packager == "" || elem.Packager == "" || present.Packager == elem.Packager) {
 			return nil, fmt.Errorf(
 				"cannot add %s because %s is already present at the same destination (%s): %w",
 				elem.Source, present.Source, present.Destination, ErrContentCollision)

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -131,7 +131,7 @@ func TestCollision(t *testing.T) {
 		require.ErrorIs(t, err, files.ErrContentCollision)
 	})
 
-	t.Run("no collision due different packagers", func(t *testing.T) {
+	t.Run("no collision due to different per-file packagers", func(t *testing.T) {
 		configuredFiles := []*files.Content{
 			{Source: "../testdata/whatever.conf", Destination: "/samedestination", Packager: "foo"},
 			{Source: "../testdata/whatever2.conf", Destination: "/samedestination", Packager: "bar"},

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -121,11 +121,33 @@ contents:
 }
 
 func TestCollision(t *testing.T) {
-	configuredFiles := []*files.Content{
-		{Source: "../testdata/whatever.conf", Destination: "/samedestination"},
-		{Source: "../testdata/whatever2.conf", Destination: "/samedestination"},
-	}
+	t.Run("collision between files for all packagers", func(t *testing.T) {
+		configuredFiles := []*files.Content{
+			{Source: "../testdata/whatever.conf", Destination: "/samedestination"},
+			{Source: "../testdata/whatever2.conf", Destination: "/samedestination"},
+		}
 
-	_, err := files.ExpandContentGlobs(configuredFiles, true)
-	require.ErrorIs(t, err, files.ErrContentCollision)
+		_, err := files.ExpandContentGlobs(configuredFiles, true)
+		require.ErrorIs(t, err, files.ErrContentCollision)
+	})
+
+	t.Run("no collision due different packagers", func(t *testing.T) {
+		configuredFiles := []*files.Content{
+			{Source: "../testdata/whatever.conf", Destination: "/samedestination", Packager: "foo"},
+			{Source: "../testdata/whatever2.conf", Destination: "/samedestination", Packager: "bar"},
+		}
+
+		_, err := files.ExpandContentGlobs(configuredFiles, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("collision between file for all packagers and file for specific packager", func(t *testing.T) {
+		configuredFiles := []*files.Content{
+			{Source: "../testdata/whatever.conf", Destination: "/samedestination", Packager: "foo"},
+			{Source: "../testdata/whatever2.conf", Destination: "/samedestination", Packager: ""},
+		}
+
+		_, err := files.ExpandContentGlobs(configuredFiles, true)
+		require.ErrorIs(t, err, files.ErrContentCollision)
+	})
 }


### PR DESCRIPTION
This PR fixes #302 by taking per-file packagers into account when detecting file destination collisions.