### PR TITLE
feat: Support for deb's config maintenance script

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -434,6 +434,10 @@ func createControl(instSize int64, md5sums []byte, info *nfpm.Info) (controlTarG
 		fileName: "templates",
 		mode:     0o644,
 	}
+	specialFiles[info.Overridables.Deb.Scripts.Config] = &fileAndMode{
+		fileName: "config",
+		mode:     0o755,
+	}
 
 	for path, destMode := range specialFiles {
 		if path != "" {

--- a/nfpm.go
+++ b/nfpm.go
@@ -289,6 +289,7 @@ type DebTriggers struct {
 type DebScripts struct {
 	Rules     string `yaml:"rules,omitempty"`
 	Templates string `yaml:"templates,omitempty"`
+	Config    string `yaml:"config,omitempty"`
 }
 
 // Scripts contains information about maintainer scripts for packages.

--- a/testdata/acceptance/rules.deb.yaml
+++ b/testdata/acceptance/rules.deb.yaml
@@ -18,3 +18,5 @@ contents:
 deb:
   scripts:
     rules: ./testdata/acceptance/scripts/rules.sh
+    templates: ./testdata/acceptance/scripts/templates
+    config: ./testdata/acceptance/scripts/config

--- a/testdata/acceptance/scripts/config
+++ b/testdata/acceptance/scripts/config
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Ok" > /tmp/config-proof
+

--- a/testdata/acceptance/scripts/templates
+++ b/testdata/acceptance/scripts/templates
@@ -1,0 +1,3 @@
+Template: templates/acceptance
+Type: string
+Description: A setting for acceptance tests

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -222,6 +222,8 @@ deb:
     rules: foo.sh
     # Deb templates file, when using debconf.
     templates: templates
+    # Deb config maintainer script for asking questions when using debconf.
+    config: config
 
   # Custom deb triggers
   triggers:


### PR DESCRIPTION
With debconf, the config script is responsible for asking any questions necessary to configure a package [1]. Without this, we're forced to ask questions in postinst, which is against best practices:

> Avoid asking questions in the postinst. Instead, the config script should ask questions using debconf, so that pre-configuration will work.

This adds the possibility to include a config script when using debconf like so:

```yaml
deb:
  scripts:
    templates: ./my/templates
    config: ./my/config
```

[1] https://manpages.debian.org/jessie/debconf-doc/debconf-devel.7.en.html
