### PR TITLE
feat: add version_schema config option to allow controlling how the version string is parsed.

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -192,6 +192,7 @@ type Info struct {
 	Platform        string `yaml:"platform,omitempty"`
 	Epoch           string `yaml:"epoch,omitempty"`
 	Version         string `yaml:"version,omitempty"`
+	VersionSchema   string `yaml:"version_schema,omitempty"`
 	Release         string `yaml:"release,omitempty"`
 	Prerelease      string `yaml:"prerelease,omitempty"`
 	VersionMetadata string `yaml:"version_metadata,omitempty"`
@@ -228,6 +229,21 @@ func (i *Info) GetChangeLog() (log *chglog.PackageChangeLog, err error) {
 		Name:    i.Name,
 		Entries: entries,
 	}, nil
+}
+
+func (i *Info) parseSemver() {
+	// parse the version as a semver so we can properly split the parts
+	// and support proper ordering for both rpm and deb
+	if v, err := semver.NewVersion(i.Version); err == nil {
+		i.Version = fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch())
+		if i.Prerelease == "" {
+			i.Prerelease = v.Prerelease()
+		}
+
+		if i.VersionMetadata == "" {
+			i.VersionMetadata = v.Metadata()
+		}
+	}
 }
 
 // Overridables contain the field which are overridable in a package.
@@ -385,6 +401,16 @@ func WithDefaults(info *Info) *Info {
 		if info.VersionMetadata == "" {
 			info.VersionMetadata = v.Metadata()
 		}
+	}
+
+	switch info.VersionSchema {
+	case "none":
+		// No change to the version or prerelease info set in the YAML file
+		break
+	case "semver":
+		fallthrough
+	default:
+		info.parseSemver()
 	}
 
 	return info

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -38,7 +38,8 @@ func TestGet(t *testing.T) {
 
 func TestDefaultsVersion(t *testing.T) {
 	info := &nfpm.Info{
-		Version: "v1.0.0",
+		Version:       "v1.0.0",
+		VersionSchema: "semver",
 	}
 	info = nfpm.WithDefaults(info)
 	require.NotEmpty(t, info.Platform)
@@ -79,6 +80,17 @@ func TestDefaultsVersion(t *testing.T) {
 	}
 	info = nfpm.WithDefaults(info)
 	require.Equal(t, "1.0.0", info.Version)
+	require.Equal(t, "2", info.Release)
+	require.Equal(t, "beta1", info.Prerelease)
+
+	info = &nfpm.Info{
+		Version:       "this.is.my.version",
+		VersionSchema: "none",
+		Release:       "2",
+		Prerelease:    "beta1",
+	}
+	info = nfpm.WithDefaults(info)
+	require.Equal(t, "this.is.my.version", info.Version)
 	require.Equal(t, "2", info.Release)
 	require.Equal(t, "beta1", info.Prerelease)
 }

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -19,6 +19,12 @@ platform: linux
 # This will expand any env var you set in the field, eg version: v${SEMVER}
 version: v1.2.3
 
+# Version Schema allows you to specify how to parse the version String.
+# Default is `semver`
+#   `semver` parse the version string as a valid semver version
+#   `none` skip trying to parse the version string and just use what is passed in
+version_schema: semver
+
 # Version Epoch.
 # Default is extracted from `version` if it is semver compatible.
 epoch: 2


### PR DESCRIPTION


closes #283