### PR TITLE
docs: fix `go install` instructions

### DIFF
--- a/www/docs/install.md
+++ b/www/docs/install.md
@@ -39,7 +39,7 @@ curl -sfL https://install.goreleaser.com/github.com/goreleaser/nfpm.sh | sh
 **go install**:
 
 ```sh
-go install github.com/goreleaser/nfpm
+go install github.com/goreleaser/nfpm/cmd/nfpm@latest
 ```
 
 **manually**:


### PR DESCRIPTION
To install with Go, the instructions need the path suffixed with `/cmd/nfpm`

Go 1.16 will bark if you don't have `@latest` on that in addition

```console
$ go install github.com/goreleaser/nfpm       
go install: version is required when current directory is not in a module
	Try 'go install github.com/goreleaser/nfpm@latest' to install the latest version
```

```console
$ go install github.com/goreleaser/nfpm@latest
go: downloading github.com/goreleaser/nfpm v1.10.3
go: downloading github.com/Masterminds/goutils v1.1.0
go: downloading github.com/mitchellh/copystructure v1.0.0
go: downloading golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9
go: downloading golang.org/x/net v0.0.0-20201209123823-ac852fbbde11
go install: package github.com/goreleaser/nfpm is not a main package
```

```console
$ go install github.com/goreleaser/nfpm/cmd/nfpm@latest
go: downloading github.com/alecthomas/kingpin v2.2.6+incompatible
go: downloading github.com/goreleaser/fileglob v0.3.1
go: downloading github.com/google/rpmpack v0.0.0-20201206194719-59e495f2b7e1
go: downloading github.com/spf13/afero v1.5.1
go: downloading github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
go: downloading github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
```