### PR TITLE
fix: deb and apk packager set file's mode failed

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -472,6 +472,8 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, sizep *int64) error
 	}
 
 	header.Name = files.ToNixPath(file.Destination[1:])
+	header.Uname = file.FileInfo.Owner
+	header.Gname = file.FileInfo.Group
 	if err = newItemInsideTarGz(tw, contents, header); err != nil {
 		return err
 	}

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -284,6 +284,8 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, md5w io.Writer) (in
 	}
 	header.Format = tar.FormatGNU
 	header.Name = normalizePath(file.Destination)
+	header.Uname = file.FileInfo.Owner
+	header.Gname = file.FileInfo.Group
 	if err := tw.WriteHeader(header); err != nil {
 		return 0, fmt.Errorf("cannot write header of %s to data.tar.gz: %w", file.Source, err)
 	}


### PR DESCRIPTION
Because `Sys()` of `Content` returns nil, so `tar.FileInfoHeader(file, file.Source)` can't populate additional fields to set `Uname` and `Gname`.
```
if sys, ok := fi.Sys().(*Header); ok {
		// This FileInfo came from a Header (not the OS). Use the
		// original Header to populate all remaining fields.
		h.Uid = sys.Uid
		h.Gid = sys.Gid
		h.Uname = sys.Uname
		h.Gname = sys.Gname
		h.AccessTime = sys.AccessTime
		h.ChangeTime = sys.ChangeTime
		if sys.Xattrs != nil {
			h.Xattrs = make(map[string]string)
			for k, v := range sys.Xattrs {
				h.Xattrs[k] = v
			}
		}
		if sys.Typeflag == TypeLink {
			// hard link
			h.Typeflag = TypeLink
			h.Size = 0
			h.Linkname = sys.Linkname
		}
		if sys.PAXRecords != nil {
			h.PAXRecords = make(map[string]string)
			for k, v := range sys.PAXRecords {
				h.PAXRecords[k] = v
			}
		}
	}
```
