### PR TITLE
feat: compression option with xz support for deb

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -127,7 +127,7 @@ func TestUpgrade(t *testing.T) {
 	}
 }
 
-func TestCompression(t *testing.T) {
+func TestRPMCompression(t *testing.T) {
 	t.Parallel()
 	format := "rpm"
 	compressFormats := []string{"gzip", "xz", "lzma"}
@@ -148,6 +148,34 @@ func TestCompression(t *testing.T) {
 							Target:    "compression",
 							Arch:      testArch,
 							BuildArgs: []string{fmt.Sprintf("compression=%s", testCompFormat)},
+						},
+					})
+				})
+			}(t, compFormat, arch)
+		}
+	}
+}
+
+func TestDebCompression(t *testing.T) {
+	t.Parallel()
+	format := "deb"
+	compressFormats := []string{"gzip", "xz", "none"}
+	for _, arch := range formatArchs[format] {
+		for _, compFormat := range compressFormats {
+			func(tt *testing.T, testCompFormat, testArch string) {
+				tt.Run(fmt.Sprintf("%s/%s/%s", format, testArch, testCompFormat), func(ttt *testing.T) {
+					ttt.Parallel()
+					if testArch == "ppc64le" && os.Getenv("NO_TEST_PPC64LE") == "true" {
+						ttt.Skip("ppc64le arch not supported in pipeline")
+					}
+					accept(ttt, acceptParms{
+						Name:   fmt.Sprintf("%s_compression_%s", testCompFormat, testArch),
+						Conf:   fmt.Sprintf("deb.%s.compression.yaml", testCompFormat),
+						Format: format,
+						Docker: dockerParams{
+							File:   fmt.Sprintf("%s.dockerfile", format),
+							Target: "compression",
+							Arch:   testArch,
 						},
 					})
 				})

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/goreleaser/chglog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xi2/xz"
 
 	"github.com/goreleaser/nfpm/v2"
 	"github.com/goreleaser/nfpm/v2/files"
@@ -512,11 +513,9 @@ func TestDebChangelogControl(t *testing.T) {
 	controlTarGz, err := createControl(0, []byte{}, info)
 	require.NoError(t, err)
 
-	controlChangelog, err := extractFileFromTarGz(controlTarGz, "changelog")
-	require.NoError(t, err)
+	controlChangelog := extractFileFromTar(t, inflate(t, "gz", controlTarGz), "changelog")
 
-	goldenChangelog, err := readAndFormatAsDebChangelog(info.Changelog, info.Name)
-	require.NoError(t, err)
+	goldenChangelog := readAndFormatAsDebChangelog(t, info.Changelog, info.Name)
 
 	assert.Equal(t, goldenChangelog, string(controlChangelog))
 }
@@ -534,8 +533,7 @@ func TestDebNoChangelogControlWithoutChangelogConfigured(t *testing.T) {
 	controlTarGz, err := createControl(0, []byte{}, info)
 	require.NoError(t, err)
 
-	_, err = extractFileFromTarGz(controlTarGz, "changelog")
-	assert.EqualError(t, err, os.ErrNotExist.Error())
+	assert.False(t, tarContains(t, inflate(t, "gz", controlTarGz), "changelog"))
 }
 
 func TestDebChangelogData(t *testing.T) {
@@ -549,18 +547,15 @@ func TestDebChangelogData(t *testing.T) {
 	err := info.Validate()
 	require.NoError(t, err)
 
-	dataTarGz, _, _, err := createDataTarGz(info)
+	dataTarGz, _, _, dataTarballName, err := createDataTarball(info)
 	require.NoError(t, err)
 
 	changelogName := fmt.Sprintf("/usr/share/doc/%s/changelog.gz", info.Name)
-	dataChangelogGz, err := extractFileFromTarGz(dataTarGz, changelogName)
-	require.NoError(t, err)
+	dataChangelogGz := extractFileFromTar(t,
+		inflate(t, dataTarballName, dataTarGz), changelogName)
 
-	dataChangelog, err := gzipInflate(dataChangelogGz)
-	require.NoError(t, err)
-
-	goldenChangelog, err := readAndFormatAsDebChangelog(info.Changelog, info.Name)
-	require.NoError(t, err)
+	dataChangelog := inflate(t, "gz", dataChangelogGz)
+	goldenChangelog := readAndFormatAsDebChangelog(t, info.Changelog, info.Name)
 
 	assert.Equal(t, goldenChangelog, string(dataChangelog))
 }
@@ -575,12 +570,12 @@ func TestDebNoChangelogDataWithoutChangelogConfigured(t *testing.T) {
 	err := info.Validate()
 	require.NoError(t, err)
 
-	dataTarGz, _, _, err := createDataTarGz(info)
+	dataTarGz, _, _, dataTarballName, err := createDataTarball(info)
 	require.NoError(t, err)
 
 	changelogName := fmt.Sprintf("/usr/share/doc/%s/changelog.gz", info.Name)
-	_, err = extractFileFromTarGz(dataTarGz, changelogName)
-	assert.EqualError(t, err, os.ErrNotExist.Error())
+
+	assert.False(t, tarContains(t, inflate(t, dataTarballName, dataTarGz), changelogName))
 }
 
 func TestDebTriggers(t *testing.T) {
@@ -608,8 +603,7 @@ func TestDebTriggers(t *testing.T) {
 	controlTarGz, err := createControl(0, []byte{}, info)
 	require.NoError(t, err)
 
-	controlTriggers, err := extractFileFromTarGz(controlTarGz, "triggers")
-	require.NoError(t, err)
+	controlTriggers := extractFileFromTar(t, inflate(t, "gz", controlTarGz), "triggers")
 
 	goldenTriggers := createTriggers(info)
 
@@ -648,8 +642,7 @@ func TestDebNoTriggersInControlIfNoneProvided(t *testing.T) {
 	controlTarGz, err := createControl(0, []byte{}, info)
 	require.NoError(t, err)
 
-	_, err = extractFileFromTarGz(controlTarGz, "triggers")
-	assert.EqualError(t, err, os.ErrNotExist.Error())
+	assert.False(t, tarContains(t, inflate(t, "gz", controlTarGz), "triggers"))
 }
 
 func TestSymlinkInFiles(t *testing.T) {
@@ -678,11 +671,11 @@ func TestSymlinkInFiles(t *testing.T) {
 	realSymlinkTarget, err := ioutil.ReadFile(symlinkTarget)
 	require.NoError(t, err)
 
-	dataTarGz, _, _, err := createDataTarGz(info)
+	dataTarGz, _, _, dataTarballName, err := createDataTarball(info)
 	require.NoError(t, err)
 
-	packagedSymlinkTarget, err := extractFileFromTarGz(dataTarGz, packagedTarget)
-	require.NoError(t, err)
+	packagedSymlinkTarget := extractFileFromTar(t,
+		inflate(t, dataTarballName, dataTarGz), packagedTarget)
 
 	assert.Equal(t, string(realSymlinkTarget), string(packagedSymlinkTarget))
 }
@@ -716,11 +709,11 @@ func TestSymlink(t *testing.T) {
 	err := info.Validate()
 	require.NoError(t, err)
 
-	dataTarGz, _, _, err := createDataTarGz(info)
+	dataTarGz, _, _, dataTarballName, err := createDataTarball(info)
 	require.NoError(t, err)
 
-	packagedSymlinkHeader, err := extractFileHeaderFromTarGz(dataTarGz, symlink)
-	require.NoError(t, err)
+	packagedSymlinkHeader := extractFileHeaderFromTar(t,
+		inflate(t, dataTarballName, dataTarGz), symlink)
 
 	assert.Equal(t, symlink, path.Join("/", packagedSymlinkHeader.Name)) // nolint:gosec
 	assert.Equal(t, uint8(tar.TypeSymlink), packagedSymlinkHeader.Typeflag)
@@ -740,13 +733,13 @@ func TestEnsureRelativePrefixInTarGzFiles(t *testing.T) {
 	err := info.Validate()
 	require.NoError(t, err)
 
-	dataTarGz, md5sums, instSize, err := createDataTarGz(info)
+	dataTarGz, md5sums, instSize, tarballName, err := createDataTarball(info)
 	require.NoError(t, err)
-	testRelativePathPrefixInTarGzFiles(t, dataTarGz)
+	testRelativePathPrefixInTar(t, inflate(t, tarballName, dataTarGz))
 
 	controlTarGz, err := createControl(instSize, md5sums, info)
 	require.NoError(t, err)
-	testRelativePathPrefixInTarGzFiles(t, controlTarGz)
+	testRelativePathPrefixInTar(t, inflate(t, "gz", controlTarGz))
 }
 
 func TestMD5Sums(t *testing.T) {
@@ -762,17 +755,18 @@ func TestMD5Sums(t *testing.T) {
 		}
 	}
 
-	dataTarGz, md5sums, instSize, err := createDataTarGz(info)
+	dataTarGz, md5sums, instSize, tarballName, err := createDataTarball(info)
 	require.NoError(t, err)
 
 	controlTarGz, err := createControl(instSize, md5sums, info)
 	require.NoError(t, err)
 
-	md5sumsFile, err := extractFileFromTarGz(controlTarGz, "./md5sums")
-	require.NoError(t, err)
+	md5sumsFile := extractFileFromTar(t, inflate(t, "gz", controlTarGz), "./md5sums")
 
 	lines := strings.Split(strings.TrimRight(string(md5sumsFile), "\n"), "\n")
 	require.Equal(t, nFiles, len(lines))
+
+	dataTar := inflate(t, tarballName, dataTarGz)
 
 	for _, line := range lines {
 		parts := strings.Fields(line)
@@ -780,20 +774,15 @@ func TestMD5Sums(t *testing.T) {
 
 		md5sum, fileName := parts[0], parts[1]
 
-		fileContent, err := extractFileFromTarGz(dataTarGz, fileName)
-		require.NoError(t, err)
-
 		digest := md5.New() // nolint:gosec
-		_, err = digest.Write(fileContent)
+		_, err = digest.Write(extractFileFromTar(t, dataTar, fileName))
 		require.NoError(t, err)
 		assert.Equal(t, md5sum, hex.EncodeToString(digest.Sum(nil)))
 	}
 }
 
-func testRelativePathPrefixInTarGzFiles(t *testing.T, tarGzFile []byte) {
-	t.Helper()
-	tarFile, err := gzipInflate(tarGzFile)
-	require.NoError(t, err)
+func testRelativePathPrefixInTar(tb testing.TB, tarFile []byte) {
+	tb.Helper()
 
 	tr := tar.NewReader(bytes.NewReader(tarFile))
 	for {
@@ -801,9 +790,9 @@ func testRelativePathPrefixInTarGzFiles(t *testing.T, tarGzFile []byte) {
 		if errors.Is(err, io.EOF) {
 			break // End of archive
 		}
-		require.NoError(t, err)
+		require.NoError(tb, err)
 
-		assert.True(t, strings.HasPrefix(hdr.Name, "./"), "%s does not start with './'", hdr.Name)
+		assert.True(tb, strings.HasPrefix(hdr.Name, "./"), "%s does not start with './'", hdr.Name)
 	}
 }
 
@@ -816,17 +805,10 @@ func TestDebsigsSignature(t *testing.T) {
 	err := Default.Package(info, &deb)
 	require.NoError(t, err)
 
-	debBinary, err := extractFileFromAr(deb.Bytes(), "debian-binary")
-	require.NoError(t, err)
-
-	controlTarGz, err := extractFileFromAr(deb.Bytes(), "control.tar.gz")
-	require.NoError(t, err)
-
-	dataTarGz, err := extractFileFromAr(deb.Bytes(), "data.tar.gz")
-	require.NoError(t, err)
-
-	signature, err := extractFileFromAr(deb.Bytes(), "_gpgorigin")
-	require.NoError(t, err)
+	debBinary := extractFileFromAr(t, deb.Bytes(), "debian-binary")
+	controlTarGz := extractFileFromAr(t, deb.Bytes(), "control.tar.gz")
+	dataTarGz := extractFileFromAr(t, deb.Bytes(), findDataTarball(t, deb.Bytes()))
+	signature := extractFileFromAr(t, deb.Bytes(), "_gpgorigin")
 
 	message := io.MultiReader(bytes.NewReader(debBinary),
 		bytes.NewReader(controlTarGz), bytes.NewReader(dataTarGz))
@@ -858,149 +840,234 @@ func TestDisableGlobbing(t *testing.T) {
 	}
 	require.NoError(t, info.Validate())
 
-	dataTarGz, _, _, err := createDataTarGz(info)
+	dataTarGz, _, _, tarballName, err := createDataTarball(info)
 	require.NoError(t, err)
 
 	expectedContent, err := ioutil.ReadFile("../testdata/{file}[")
 	require.NoError(t, err)
 
-	actualContent, err := extractFileFromTarGz(dataTarGz, "/test/{file}[")
-	require.NoError(t, err)
+	actualContent := extractFileFromTar(t, inflate(t, tarballName, dataTarGz), "/test/{file}[")
 
 	assert.Equal(t, expectedContent, actualContent)
 }
 
-func extractFileFromTarGz(tarGzFile []byte, filename string) ([]byte, error) {
-	tarFile, err := gzipInflate(tarGzFile)
-	if err != nil {
-		return nil, err
+func TestCompressionAlgorithms(t *testing.T) {
+	testCases := []struct {
+		algorithm       string
+		dataTarballName string
+	}{
+		{"gzip", "data.tar.gz"},
+		{"", "data.tar.gz"}, // test current default
+		{"xz", "data.tar.xz"},
+		{"none", "data.tar"},
 	}
 
-	tr := tar.NewReader(bytes.NewReader(tarFile))
-	for {
-		hdr, err := tr.Next()
-		if errors.Is(err, io.EOF) {
-			break // End of archive
-		}
-		if err != nil {
-			return nil, err
-		}
+	for _, testCase := range testCases {
+		testCase := testCase
 
-		if path.Join("/", hdr.Name) != path.Join("/", filename) { // nolint:gosec
-			continue
-		}
+		t.Run(testCase.algorithm, func(t *testing.T) {
+			info := exampleInfo()
+			info.Deb.Compression = testCase.algorithm
 
-		fileContents, err := ioutil.ReadAll(tr)
-		if err != nil {
-			return nil, err
-		}
+			var deb bytes.Buffer
 
-		return fileContents, nil
+			err := Default.Package(info, &deb)
+			require.NoError(t, err)
+
+			dataTarballName := findDataTarball(t, deb.Bytes())
+			assert.Equal(t, dataTarballName, testCase.dataTarballName)
+
+			dataTarGz := extractFileFromAr(t, deb.Bytes(), dataTarballName)
+			dataTar := inflate(t, dataTarballName, dataTarGz)
+
+			for _, file := range info.Contents {
+				tarContains(t, dataTar, file.Destination)
+			}
+		})
 	}
-
-	return nil, os.ErrNotExist
 }
 
-func extractFileHeaderFromTarGz(tarGzFile []byte, filename string) (*tar.Header, error) {
-	tarFile, err := gzipInflate(tarGzFile)
-	if err != nil {
-		return nil, err
-	}
-
-	tr := tar.NewReader(bytes.NewReader(tarFile))
-	for {
-		hdr, err := tr.Next()
-		if errors.Is(err, io.EOF) {
-			break // End of archive
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		if path.Join("/", hdr.Name) != path.Join("/", filename) { // nolint:gosec
-			continue
-		}
-
-		return hdr, nil
-	}
-
-	return nil, os.ErrNotExist
-}
-
-func gzipInflate(data []byte) ([]byte, error) {
-	gzr, err := gzip.NewReader(bytes.NewReader(data))
-	if err != nil {
-		return nil, err
-	}
-
-	inflatedData, err := ioutil.ReadAll(gzr)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = gzr.Close(); err != nil {
-		return nil, err
-	}
-
-	return inflatedData, nil
-}
-
-func readAndFormatAsDebChangelog(changelogFileName, packageName string) (string, error) {
-	changelogEntries, err := chglog.Parse(changelogFileName)
-	if err != nil {
-		return "", err
-	}
-
-	tpl, err := chglog.DebTemplate()
-	if err != nil {
-		return "", err
-	}
-
-	debChangelog, err := chglog.FormatChangelog(&chglog.PackageChangeLog{
-		Name:    packageName,
-		Entries: changelogEntries,
-	}, tpl)
-	if err != nil {
-		return "", err
-	}
-
-	return strings.TrimSpace(debChangelog) + "\n", nil
-}
-
-func symlinkTo(tb testing.TB, fileName string) string {
+func extractFileFromTar(tb testing.TB, tarFile []byte, filename string) []byte {
 	tb.Helper()
-	target, err := filepath.Abs(fileName)
-	assert.NoError(tb, err)
 
-	symlinkName := filepath.Join(tb.TempDir(), "symlink")
-	err = os.Symlink(target, symlinkName)
-	assert.NoError(tb, err)
-
-	return files.ToNixPath(symlinkName)
-}
-
-func extractFileFromAr(arFile []byte, filename string) ([]byte, error) {
-	tr := ar.NewReader(bytes.NewReader(arFile))
+	tr := tar.NewReader(bytes.NewReader(tarFile))
 	for {
 		hdr, err := tr.Next()
 		if errors.Is(err, io.EOF) {
 			break // End of archive
 		}
-		if err != nil {
-			return nil, err
-		}
+		require.NoError(tb, err)
 
 		if path.Join("/", hdr.Name) != path.Join("/", filename) {
 			continue
 		}
 
 		fileContents, err := ioutil.ReadAll(tr)
-		if err != nil {
-			return nil, err
-		}
+		require.NoError(tb, err)
 
-		return fileContents, nil
+		return fileContents
 	}
 
-	return nil, os.ErrNotExist
+	tb.Fatalf("file %q does not exist in tar", filename)
+
+	return nil
+}
+
+func tarContains(tb testing.TB, tarFile []byte, filename string) bool {
+	tb.Helper()
+
+	tr := tar.NewReader(bytes.NewReader(tarFile))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break // End of archive
+		}
+		require.NoError(tb, err)
+
+		if path.Join("/", hdr.Name) == path.Join("/", filename) { // nolint:gosec
+			return true
+		}
+	}
+
+	return false
+}
+
+func extractFileHeaderFromTar(tb testing.TB, tarFile []byte, filename string) *tar.Header {
+	tb.Helper()
+
+	tr := tar.NewReader(bytes.NewReader(tarFile))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break // End of archive
+		}
+		require.NoError(tb, err)
+
+		if path.Join("/", hdr.Name) != path.Join("/", filename) { // nolint:gosec
+			continue
+		}
+
+		return hdr
+	}
+
+	tb.Fatalf("file %q does not exist in tar", filename)
+
+	return nil
+}
+
+func inflate(tb testing.TB, nameOrType string, data []byte) []byte {
+	tb.Helper()
+
+	ext := filepath.Ext(nameOrType)
+	if ext == "" {
+		ext = nameOrType
+	} else {
+		ext = strings.TrimPrefix(ext, ".")
+	}
+
+	dataReader := bytes.NewReader(data)
+
+	var (
+		inflateReadCloser io.ReadCloser
+		err               error
+	)
+
+	switch ext {
+	case "gz", "gzip":
+		inflateReadCloser, err = gzip.NewReader(dataReader)
+		require.NoError(tb, err)
+	case "xz":
+		r, err := xz.NewReader(dataReader, 0)
+		require.NoError(tb, err)
+		inflateReadCloser = io.NopCloser(r)
+	case "tar", "": // no compression
+		inflateReadCloser = io.NopCloser(dataReader)
+	default:
+		tb.Fatalf("invalid inflation type: %s", ext)
+	}
+
+	inflatedData, err := ioutil.ReadAll(inflateReadCloser)
+	require.NoError(tb, err)
+
+	err = inflateReadCloser.Close()
+	require.NoError(tb, err)
+
+	return inflatedData
+}
+
+func readAndFormatAsDebChangelog(tb testing.TB, changelogFileName, packageName string) string {
+	tb.Helper()
+
+	changelogEntries, err := chglog.Parse(changelogFileName)
+	require.NoError(tb, err)
+
+	tpl, err := chglog.DebTemplate()
+	require.NoError(tb, err)
+
+	debChangelog, err := chglog.FormatChangelog(&chglog.PackageChangeLog{
+		Name:    packageName,
+		Entries: changelogEntries,
+	}, tpl)
+	require.NoError(tb, err)
+
+	return strings.TrimSpace(debChangelog) + "\n"
+}
+
+func symlinkTo(tb testing.TB, fileName string) string {
+	tb.Helper()
+	target, err := filepath.Abs(fileName)
+	require.NoError(tb, err)
+
+	symlinkName := filepath.Join(tb.TempDir(), "symlink")
+	err = os.Symlink(target, symlinkName)
+	require.NoError(tb, err)
+
+	return files.ToNixPath(symlinkName)
+}
+
+func findDataTarball(tb testing.TB, arFile []byte) string {
+	tb.Helper()
+
+	tr := ar.NewReader(bytes.NewReader(arFile))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break // End of archive
+		}
+		require.NoError(tb, err)
+
+		if strings.HasPrefix(path.Join("/", hdr.Name), "/data.tar") {
+			return hdr.Name
+		}
+	}
+
+	tb.Fatalf("data taball does not exist in ar")
+
+	return ""
+}
+
+func extractFileFromAr(tb testing.TB, arFile []byte, filename string) []byte {
+	tb.Helper()
+
+	tr := ar.NewReader(bytes.NewReader(arFile))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break // End of archive
+		}
+		require.NoError(tb, err)
+
+		if path.Join("/", hdr.Name) != path.Join("/", filename) {
+			continue
+		}
+
+		fileContents, err := ioutil.ReadAll(tr)
+		require.NoError(tb, err)
+
+		return fileContents
+	}
+
+	tb.Fatalf("file %q does not exist in ar", filename)
+
+	return nil
 }

--- a/nfpm.go
+++ b/nfpm.go
@@ -306,10 +306,11 @@ type APKScripts struct {
 
 // Deb is custom configs that are only available on deb packages.
 type Deb struct {
-	Scripts   DebScripts   `yaml:"scripts,omitempty" jsonschema:"title=scripts"`
-	Triggers  DebTriggers  `yaml:"triggers,omitempty" jsonschema:"title=triggers"`
-	Breaks    []string     `yaml:"breaks,omitempty" jsonschema:"title=breaks"`
-	Signature DebSignature `yaml:"signature,omitempty" jsonschema:"title=signature"`
+	Scripts     DebScripts   `yaml:"scripts,omitempty" jsonschema:"title=scripts"`
+	Triggers    DebTriggers  `yaml:"triggers,omitempty" jsonschema:"title=triggers"`
+	Breaks      []string     `yaml:"breaks,omitempty" jsonschema:"title=breaks"`
+	Signature   DebSignature `yaml:"signature,omitempty" jsonschema:"title=signature"`
+	Compression string       `yaml:"compression,omitempty" jsonschema:"title=compression algorithm to be used,enum=gzip,enum=xz,enum=none,default=gzip"`
 }
 
 type DebSignature struct {

--- a/testdata/acceptance/deb.dockerfile
+++ b/testdata/acceptance/deb.dockerfile
@@ -146,6 +146,13 @@ RUN dpkg -i /tmp/foo.deb 2>&1 | grep "foo breaks dummy"
 RUN dpkg -r dummy
 RUN dpkg -i /tmp/foo.deb
 
+# ---- compression test ----
+FROM min AS compression
+RUN test -e /usr/local/bin/fake
+RUN test -f /etc/foo/whatever.conf
+RUN echo wat >> /etc/foo/whatever.conf
+RUN dpkg -r foo
+RUN test ! -f /usr/local/bin/fake
 
 # ---- upgrade test ----
 FROM test_base AS upgrade

--- a/testdata/acceptance/deb.gzip.compression.yaml
+++ b/testdata/acceptance/deb.gzip.compression.yaml
@@ -1,0 +1,19 @@
+name: "foo"
+arch: "${BUILD_ARCH}"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/local/bin/fake
+  - src: ./testdata/whatever.conf
+    dst: /etc/foo/whatever.conf
+    type: config
+deb:
+  compression: "gzip"

--- a/testdata/acceptance/deb.none.compression.yaml
+++ b/testdata/acceptance/deb.none.compression.yaml
@@ -1,0 +1,19 @@
+name: "foo"
+arch: "${BUILD_ARCH}"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/local/bin/fake
+  - src: ./testdata/whatever.conf
+    dst: /etc/foo/whatever.conf
+    type: config
+deb:
+  compression: "none"

--- a/testdata/acceptance/deb.xz.compression.yaml
+++ b/testdata/acceptance/deb.xz.compression.yaml
@@ -1,0 +1,19 @@
+name: "foo"
+arch: "${BUILD_ARCH}"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/local/bin/fake
+  - src: ./testdata/whatever.conf
+    dst: /etc/foo/whatever.conf
+    type: config
+deb:
+  compression: "xz"

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -255,7 +255,7 @@ deb:
     - some-package
 
   # Compression algorithm (gzip (default), xz or none).
-  compression: lzma
+  compression: xz
 
   # The package is signed if a key_file is set
   signature:

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -165,7 +165,6 @@ contents:
       owner: notRoot
       group: notRoot
 
-
 # Empty folders your package may need created. (overridable)
 empty_folders:
   - /var/log/foo
@@ -211,7 +210,7 @@ rpm:
   # description, but can be explicitly provided here.
   summary: Explicit Summary for Sample Package
 
-  # Compression algorithm.
+  # Compression algorithm (gzip (default), lzma or xz).
   compression: lzma
 
   # The package is signed if a key_file is set
@@ -255,6 +254,9 @@ deb:
   breaks:
     - some-package
 
+  # Compression algorithm (gzip (default), xz or none).
+  compression: lzma
+
   # The package is signed if a key_file is set
   signature:
     # PGP secret key (can also be ASCII-armored). The passphrase is taken
@@ -292,7 +294,6 @@ Templating is not and will not be supported.
 
 If you really need it, you can build on top of nFPM, use `envsubst`, `jsonnet`
 or apply some other templating on top of it.
-
 
 ## JSON Schema
 


### PR DESCRIPTION
This PR adds a `compression` option for `deb` files. Currently the following values are supported:

* `gzip` (default)
* `xz` (future default)
* `none` (no compression)

I think the best way to move forward is to keep `gzip` as default for now and wait for feedback from the users that use `xz`. If everything works great (and if `xz` build times are acceptable), we should make `xz` the default in a following release.

Closes #361.