### PR TITLE
feat: Use xz as default compression for deb.

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -179,15 +179,15 @@ func createDataTarball(info *nfpm.Info) (dataTarBall, md5sums []byte,
 	)
 
 	switch info.Deb.Compression {
-	case "", "gzip": // the default for now
-		dataTarballWriteCloser = gzip.NewWriter(&dataTarball)
-		name = "data.tar.gz"
-	case "xz":
+	case "", "xz": // the default
 		dataTarballWriteCloser, err = xz.NewWriter(&dataTarball)
 		if err != nil {
 			return nil, nil, 0, "", err
 		}
 		name = "data.tar.xz"
+	case "gzip":
+		dataTarballWriteCloser = gzip.NewWriter(&dataTarball)
+		name = "data.tar.gz"
 	case "none":
 		dataTarballWriteCloser = nopCloser{Writer: &dataTarball}
 		name = "data.tar"

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -856,9 +856,9 @@ func TestCompressionAlgorithms(t *testing.T) {
 		algorithm       string
 		dataTarballName string
 	}{
-		{"gzip", "data.tar.gz"},
-		{"", "data.tar.gz"}, // test current default
+		{"", "data.tar.xz"}, // test current default
 		{"xz", "data.tar.xz"},
+		{"gzip", "data.tar.gz"},
 		{"none", "data.tar"},
 	}
 

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -254,7 +254,7 @@ deb:
   breaks:
     - some-package
 
-  # Compression algorithm (gzip (default), xz or none).
+  # Compression algorithm (xz (default), gzip or none).
   compression: xz
 
   # The package is signed if a key_file is set


### PR DESCRIPTION
This PR updates the default compression method for `deb` packages to `xz` to be in line with upstream packaging practices.

**It is meant to be merged at a later point when we've gathered some feedback about our `xz` compression implementation**