### PR TITLE
docs: fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Why
 
 While [fpm][] is great, for me, it is a bummer that it depends on `ruby`, `tar`
-and other softwares.
+and other software.
 
 I wanted something that could be used as a binary and/or as a library and that
 was really simple.


### PR DESCRIPTION
'software' is not a 'countable' kind of noun which attracts pluralization.  It's like 'traffic' or 'mail', which are the same kind of noun and also do not normally get pluralized as nouns.