### PR TITLE
Fix: Improve performance of content destination collision detection.

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -116,33 +116,35 @@ func (c *Content) Sys() interface{} {
 
 // ExpandContentGlobs gathers all of the real files to be copied into the package.
 func ExpandContentGlobs(contents Contents, disableGlobbing bool) (files Contents, err error) {
+	options := []fileglob.OptFunc{fileglob.MatchDirectoryIncludesContents}
+	if disableGlobbing {
+		options = append(options, fileglob.QuoteMeta)
+	}
+
 	for _, f := range contents {
 		var globbed map[string]string
 
 		switch f.Type {
 		case "ghost", "symlink":
 			// Ghost and symlink files need to be in the list, but dont glob them because they do not really exist
-			files, err = appendWithUniqueDestination(files, f.WithFileInfoDefaults())
+			files = append(files, f.WithFileInfoDefaults())
+		default:
+			globbed, err = glob.Glob(f.Source, f.Destination, options...)
 			if err != nil {
 				return nil, err
 			}
 
-			continue
+			files, err = appendGlobbedFiles(files, globbed, f)
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		options := []fileglob.OptFunc{fileglob.MatchDirectoryIncludesContents}
-		if disableGlobbing {
-			options = append(options, fileglob.QuoteMeta)
-		}
-		globbed, err = glob.Glob(f.Source, f.Destination, options...)
-		if err != nil {
-			return nil, err
-		}
+	}
 
-		files, err = appendGlobbedFiles(globbed, f, files)
-		if err != nil {
-			return nil, err
-		}
+	err = checkNoCollisions(files)
+	if err != nil {
+		return nil, err
 	}
 
 	// sort the files for reproducibility and general cleanliness
@@ -151,8 +153,7 @@ func ExpandContentGlobs(contents Contents, disableGlobbing bool) (files Contents
 	return files, nil
 }
 
-func appendGlobbedFiles(globbed map[string]string, origFile *Content, incFiles Contents) (files Contents, err error) {
-	files = append(files, incFiles...)
+func appendGlobbedFiles(all Contents, globbed map[string]string, origFile *Content) (Contents, error) {
 	for src, dst := range globbed {
 		newFile := &Content{
 			Destination: ToNixPath(dst),
@@ -162,28 +163,21 @@ func appendGlobbedFiles(globbed map[string]string, origFile *Content, incFiles C
 			Packager:    origFile.Packager,
 		}
 
-		files, err = appendWithUniqueDestination(files, newFile.WithFileInfoDefaults())
-		if err != nil {
-			return nil, err
-		}
+		all = append(all, newFile.WithFileInfoDefaults())
 	}
 
-	return files, nil
+	return all, nil
 }
 
 var ErrContentCollision = fmt.Errorf("content collision")
 
-func appendWithUniqueDestination(slice []*Content, elems ...*Content) ([]*Content, error) {
+func checkNoCollisions(contents Contents) error {
 	alreadyPresent := map[string]*Content{}
 
-	for _, presentElem := range slice {
-		alreadyPresent[presentElem.Destination] = presentElem
-	}
-
-	for _, elem := range elems {
+	for _, elem := range contents {
 		present, ok := alreadyPresent[elem.Destination]
 		if ok && (present.Packager == "" || elem.Packager == "" || present.Packager == elem.Packager) {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"cannot add %s because %s is already present at the same destination (%s): %w",
 				elem.Source, present.Source, present.Destination, ErrContentCollision)
 		}
@@ -191,7 +185,7 @@ func appendWithUniqueDestination(slice []*Content, elems ...*Content) ([]*Conten
 		alreadyPresent[elem.Destination] = elem
 	}
 
-	return append(slice, elems...), nil
+	return nil
 }
 
 // ToNixPath converts the given path to a nix-style path.

--- a/internal/cmd/package.go
+++ b/internal/cmd/package.go
@@ -72,10 +72,6 @@ func doPackage(configPath, target, packager string) error {
 
 	info = nfpm.WithDefaults(info)
 
-	if err = nfpm.Validate(info); err != nil {
-		return err
-	}
-
 	fmt.Printf("using %s packager...\n", packager)
 	pkg, err := nfpm.Get(packager)
 	if err != nil {

--- a/nfpm.go
+++ b/nfpm.go
@@ -75,7 +75,7 @@ func ParseWithEnvMapping(in io.Reader, mapping func(string) string) (config Conf
 
 	WithDefaults(&config.Info)
 
-	return config, config.Validate()
+	return config, nil
 }
 
 // ParseFile decodes YAML data from a file path into a configuration struct.


### PR DESCRIPTION
This PR fixes #387 and #393 by reducing the algorithmic complexity of the content destination collision detection. Previously when appending an element, the destination was compared to all other elements in the content list. Now we simply append and check for collisions once at the end with a single pass through all elements.

For 150000 files with random destinations, the performance compares as follows:
```
Before: BenchmarkExpandContentGlobs-4   	       1	2982879539110 ns/op
Now   : BenchmarkExpandContentGlobs-4   	       1	9052880061 ns/op
```
**That's a 320x improvement from 50 minutes to 9 seconds for extreme use cases!**

Here's the benchmark code:
```Go
func BenchmarkExpandContentGlobs(b *testing.B) {
	contents := testContents(150000)
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		_, err := files.ExpandContentGlobs(contents, true)
		if err != nil {
			b.Fatalf("expand content globs: %v", err)
		}
	}
}

func testContents(n int) files.Contents {
	contents := make(files.Contents, n)

	for i := 0; i < n; i++ {
		contents[i] = &files.Content{
			Source:      "../testdata/whatever.conf",
			Destination: randomString(),
		}
	}

	return contents
}

const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

func randomString() string {
	b := make([]byte, 5+rand.Intn(20))
	for i := range b {
		b[i] = letters[rand.Intn(len(letters))]
	}
	return string(b)
}
```

Thank you @mjmjelde for reporting this.