### PR TITLE
feat: Directory content type with custom attributes

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -189,6 +189,7 @@ func TestRPMSpecific(t *testing.T) {
 	format := "rpm"
 	testNames := []string{
 		"release",
+		"directories",
 	}
 	for _, name := range testNames {
 		for _, arch := range formatArchs[format] {

--- a/apk/apk.go
+++ b/apk/apk.go
@@ -403,7 +403,7 @@ func createBuilderData(info *nfpm.Info, sizep *int64) func(tw *tar.Writer) error
 func createFilesInsideTarGz(info *nfpm.Info, tw *tar.Writer, created map[string]bool, sizep *int64) (err error) {
 	// create explicit directories first
 	for _, file := range info.Contents {
-		// at this point, we don't are about other types yet
+		// at this point, we don't care about other types yet
 		if file.Type != "dir" {
 			continue
 		}

--- a/apk/apk.go
+++ b/apk/apk.go
@@ -417,7 +417,7 @@ func createFilesInsideTarGz(info *nfpm.Info, tw *tar.Writer, created map[string]
 		}
 
 		err = tw.WriteHeader(&tar.Header{
-			Name:     file.Destination,
+			Name:     files.ToNixPath(strings.Trim(file.Destination, "/") + "/"),
 			Mode:     int64(file.FileInfo.Mode),
 			Typeflag: tar.TypeDir,
 			Format:   tar.FormatGNU,
@@ -522,7 +522,7 @@ func createTree(tarw *tar.Writer, dst string, created map[string]bool) error {
 
 func pathsToCreate(dst string) []string {
 	paths := []string{}
-	base := strings.TrimPrefix(dst, "/")
+	base := strings.Trim(dst, "/")
 	for {
 		base = filepath.Dir(base)
 		if base == "." {

--- a/apk/apk.go
+++ b/apk/apk.go
@@ -449,11 +449,6 @@ func createFilesInsideTarGz(info *nfpm.Info, tw *tar.Writer, created map[string]
 			continue
 		case "symlink":
 			err = createSymlinkInsideTarGz(file, tw)
-		case "doc", "licence", "license", "readme", "config", "config|noreplace":
-			// nolint:gocritic
-			// ignoring `emptyFallthrough: remove empty case containing only
-			// fallthrough to default case`
-			fallthrough
 		default:
 			err = copyToTarAndDigest(file, tw, sizep)
 		}

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -120,7 +120,7 @@ func TestCreateBuilderData(t *testing.T) {
 
 	require.NoError(t, builderData(tw))
 
-	require.Equal(t, 11784, buf.Len())
+	require.Equal(t, 12288, buf.Len())
 }
 
 func TestCombineToApk(t *testing.T) {

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -120,7 +120,7 @@ func TestCreateBuilderData(t *testing.T) {
 
 	require.NoError(t, builderData(tw))
 
-	require.Equal(t, 11786, buf.Len())
+	require.Equal(t, 11784, buf.Len())
 }
 
 func TestCombineToApk(t *testing.T) {

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -518,7 +518,7 @@ func TestDirectories(t *testing.T) {
 	err := createFilesInsideTarGz(info, tar.NewWriter(&buf), make(map[string]bool), &size)
 	require.NoError(t, err)
 
-	// for debs all implicit or explicit directories are created in the tarball
+	// for apks all implicit or explicit directories are created in the tarball
 	h := extractFileHeaderFromTar(t, buf.Bytes(), "/etc")
 	require.NoError(t, err)
 	require.Equal(t, h.Typeflag, byte(tar.TypeDir))

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -269,7 +269,7 @@ func createFilesInsideDataTar(info *nfpm.Info, tw *tar.Writer,
 	created map[string]bool) (md5buf bytes.Buffer, instSize int64, err error) {
 	// create explicit directories first
 	for _, file := range info.Contents {
-		// at this point, we don't are about other types yet
+		// at this point, we don't care about other types yet
 		if file.Type != "dir" {
 			continue
 		}

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -316,11 +316,6 @@ func createFilesInsideDataTar(info *nfpm.Info, tw *tar.Writer,
 			continue
 		case "symlink":
 			err = createSymlinkInsideTar(file, tw)
-		case "doc", "licence", "license", "readme", "config", "config|noreplace":
-			// nolint:gocritic
-			// ignoring `emptyFallthrough: remove empty case containing only
-			// fallthrough to default case`
-			fallthrough
 		default:
 			size, err = copyToTarAndDigest(file, tw, &md5buf)
 		}

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -275,7 +275,7 @@ func createFilesInsideDataTar(info *nfpm.Info, tw *tar.Writer,
 		}
 
 		err = tw.WriteHeader(&tar.Header{
-			Name:     file.Destination,
+			Name:     files.ToNixPath(strings.Trim(file.Destination, "/") + "/"),
 			Mode:     int64(file.FileInfo.Mode),
 			Typeflag: tar.TypeDir,
 			Format:   tar.FormatGNU,
@@ -599,7 +599,7 @@ func createTree(tarw *tar.Writer, dst string, created map[string]bool) error {
 
 func pathsToCreate(dst string) []string {
 	paths := []string{}
-	base := strings.TrimPrefix(dst, "/")
+	base := strings.Trim(dst, "/")
 	for {
 		base = filepath.Dir(base)
 		if base == "." {

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -798,6 +798,10 @@ func TestDirectories(t *testing.T) {
 		{
 			Destination: "/etc/bar",
 			Type:        "dir",
+			FileInfo: &files.ContentFileInfo{
+				Owner: "test",
+				Mode:  0o700,
+			},
 		},
 		{
 			Destination: "/etc/baz",
@@ -821,9 +825,57 @@ func TestDirectories(t *testing.T) {
 	h = extractFileHeaderFromTar(t, dataTarball, "/etc/bar")
 	require.NoError(t, err)
 	require.Equal(t, h.Typeflag, byte(tar.TypeDir))
+	require.Equal(t, h.Mode, int64(0o700))
+	require.Equal(t, h.Uname, "test")
 	h = extractFileHeaderFromTar(t, dataTarball, "/etc/baz")
 	require.NoError(t, err)
 	require.Equal(t, h.Typeflag, byte(tar.TypeDir))
+}
+
+func TestNoDuplicateContents(t *testing.T) {
+	info := exampleInfo()
+	info.Contents = []*files.Content{
+		{
+			Source:      "../testdata/whatever.conf",
+			Destination: "/etc/foo/file",
+		},
+		{
+			Source:      "../testdata/whatever.conf",
+			Destination: "/etc/foo/file2",
+		},
+		{
+			Destination: "/etc/foo",
+			Type:        "dir",
+		},
+		{
+			Destination: "/etc/baz",
+			Type:        "dir",
+		},
+	}
+
+	require.NoError(t, info.Validate())
+
+	deflatedDataTarball, _, _, dataTarballName, err := createDataTarball(info)
+	require.NoError(t, err)
+	dataTarball := inflate(t, dataTarballName, deflatedDataTarball)
+
+	exists := map[string]bool{}
+
+	tr := tar.NewReader(bytes.NewReader(dataTarball))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break // End of archive
+		}
+		require.NoError(t, err)
+
+		_, ok := exists[hdr.Name]
+		if ok {
+			t.Fatalf("%s exists more than once in tarball", hdr.Name)
+		}
+
+		exists[hdr.Name] = true
+	}
 }
 
 func testRelativePathPrefixInTar(tb testing.TB, tarFile []byte) {

--- a/files/files.go
+++ b/files/files.go
@@ -45,7 +45,7 @@ func (c Contents) Less(i, j int) bool {
 	a, b := c[i], c[j]
 
 	if a.Destination != b.Destination {
-		return a.Destination != b.Destination
+		return a.Destination < b.Destination
 	}
 
 	if a.Type != b.Type {

--- a/files/files.go
+++ b/files/files.go
@@ -153,7 +153,8 @@ func ExpandContentGlobs(contents Contents, disableGlobbing bool) (files Contents
 
 		switch f.Type {
 		case "ghost", "symlink", "dir":
-			// Ghost and symlink files need to be in the list, but dont glob them because they do not really exist
+			// Ghost, symlinks and dirs need to be in the list, but dont glob
+			// them because they do not really exist
 			files = append(files, f.WithFileInfoDefaults())
 		default:
 			globbed, err = glob.Glob(f.Source, f.Destination, options...)

--- a/files/files.go
+++ b/files/files.go
@@ -44,17 +44,15 @@ func (c Contents) Swap(i, j int) {
 func (c Contents) Less(i, j int) bool {
 	a, b := c[i], c[j]
 
-	if a.Type == "dir" || b.Type != "dir" {
-		return true
+	if a.Destination != b.Destination {
+		return a.Destination != b.Destination
 	}
 
 	if a.Type != b.Type {
-		return len(a.Type) < len(b.Type)
+		return a.Type < b.Type
 	}
-	if a.Source != b.Source {
-		return a.Source < b.Source
-	}
-	return a.Destination < b.Destination
+
+	return a.Packager < b.Packager
 }
 
 func (c Contents) ContainsDestination(dst string) bool {

--- a/nfpm.go
+++ b/nfpm.go
@@ -378,7 +378,7 @@ func Validate(info *Info) (err error) {
 
 		for _, emptyFolder := range info.EmptyFolders {
 			if contents.ContainsDestination(emptyFolder) {
-				return fmt.Errorf("empty folder already exists in contents")
+				return fmt.Errorf("empty folder already exists in contents: %s", emptyFolder)
 			}
 
 			contents = append(contents, &files.Content{
@@ -387,6 +387,10 @@ func Validate(info *Info) (err error) {
 			})
 		}
 	}
+
+	// The deprecated EmptyFolders are already converted to contents, so we
+	// remove it such that Validate can be called more than once.
+	info.EmptyFolders = nil
 
 	info.Contents = contents
 

--- a/nfpm.go
+++ b/nfpm.go
@@ -371,7 +371,24 @@ func Validate(info *Info) (err error) {
 		return err
 	}
 
+	if len(info.EmptyFolders) > 0 {
+		fmt.Fprintf(os.Stderr, "empty_folders is deprecated, create content with type "+
+			"'dir' and directoy name as 'dst' instead")
+
+		for _, emptyFolder := range info.EmptyFolders {
+			if contents.ContainsDestination(emptyFolder) {
+				return fmt.Errorf("empty folder already exists in contents")
+			}
+
+			contents = append(contents, &files.Content{
+				Destination: emptyFolder,
+				Type:        "dir",
+			})
+		}
+	}
+
 	info.Contents = contents
+
 	return nil
 }
 

--- a/nfpm.go
+++ b/nfpm.go
@@ -372,8 +372,9 @@ func Validate(info *Info) (err error) {
 	}
 
 	if len(info.EmptyFolders) > 0 {
-		fmt.Fprintf(os.Stderr, "empty_folders is deprecated, create content with type "+
-			"'dir' and directoy name as 'dst' instead")
+		fmt.Fprintf(os.Stderr, "DEPRECATION WARNING: 'empty_folders' is deprecated and "+
+			"will be removed in a future version, create content with type 'dir' and "+
+			"directoy name as 'dst' instead")
 
 		for _, emptyFolder := range info.EmptyFolders {
 			if contents.ContainsDestination(emptyFolder) {

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -365,11 +365,6 @@ func createFilesInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) (err error) {
 }
 
 func asRPMDirectory(content *files.Content) (*rpmpack.RPMFile, error) {
-	if content.Source != "" {
-		return nil, fmt.Errorf(
-			"content of type 'dir' cannot have 'src', use 'dst' as directory name")
-	}
-
 	return &rpmpack.RPMFile{
 		Name:  content.Destination,
 		Mode:  uint(content.Mode()) | tagDirectory,

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -29,6 +29,8 @@ const (
 
 	// Symbolic link
 	tagLink = 0o120000
+	// Directory
+	tagDirectory = 0o40000
 
 	changelogNotesTemplate = `
 {{- range .Changes }}{{$note := splitList "\n" .Note}}
@@ -315,10 +317,6 @@ func addScriptFiles(info *nfpm.Info, rpm *rpmpack.RPM) error {
 }
 
 func createFilesInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) (err error) {
-	// sort.Slice(info.Contents, func(i, j int) bool {
-	// 	return info.Contents[i].Type == "dir" && info.Contents[j].Type != "dir"
-	// })
-
 	for _, content := range info.Contents {
 		if content.Packager != "" && content.Packager != packagerName {
 			continue
@@ -361,8 +359,6 @@ func createFilesInsideRPM(info *nfpm.Info, rpm *rpmpack.RPM) (err error) {
 	return nil
 }
 
-var rpmDirectoryFlag uint = 0o40000
-
 func asRPMDirectory(content *files.Content) (*rpmpack.RPMFile, error) {
 	if content.Source != "" {
 		return nil, fmt.Errorf(
@@ -371,7 +367,7 @@ func asRPMDirectory(content *files.Content) (*rpmpack.RPMFile, error) {
 
 	return &rpmpack.RPMFile{
 		Name:  content.Destination,
-		Mode:  uint(content.Mode()) | rpmDirectoryFlag,
+		Mode:  uint(content.Mode()) | tagDirectory,
 		MTime: uint32(time.Now().Unix()),
 		Owner: content.FileInfo.Owner,
 		Group: content.FileInfo.Group,

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -786,12 +786,12 @@ func TestDirectories(t *testing.T) {
 	// claiming explicit ownership of /etc/bar which already contains a file
 	h, err := extractFileHeaderFromRpm(rpmFileBuffer.Bytes(), "/etc/bar")
 	require.NoError(t, err)
-	require.NotEqual(t, h.Mode()&int(rpmDirectoryFlag), 0)
+	require.NotEqual(t, h.Mode()&int(tagDirectory), 0)
 
 	// creating an empty folder (which also implies ownership)
 	h, err = extractFileHeaderFromRpm(rpmFileBuffer.Bytes(), "/etc/baz")
 	require.NoError(t, err)
-	require.Equal(t, h.Mode(), int(rpmDirectoryFlag|0o700))
+	require.Equal(t, h.Mode(), int(tagDirectory|0o700))
 }
 
 func extractFileFromRpm(rpm []byte, filename string) ([]byte, error) {

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -64,10 +64,14 @@ func exampleInfo() *nfpm.Info {
 					Destination: "/etc/fake/fake.conf",
 					Type:        "config",
 				},
-			},
-			EmptyFolders: []string{
-				"/var/log/whatever",
-				"/usr/share/whatever",
+				{
+					Destination: "/var/log/whatever",
+					Type:        "dir",
+				},
+				{
+					Destination: "/usr/share/whatever",
+					Type:        "dir",
+				},
 			},
 			Scripts: nfpm.Scripts{
 				PreInstall:  "../testdata/scripts/preinstall.sh",
@@ -743,6 +747,51 @@ func TestDisableGlobbing(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedContent, actualContent)
+}
+
+func TestDirectories(t *testing.T) {
+	info := exampleInfo()
+	info.Contents = []*files.Content{
+		{
+			Source:      "../testdata/whatever.conf",
+			Destination: "/etc/foo/file",
+		},
+		{
+			Source:      "../testdata/whatever.conf",
+			Destination: "/etc/bar/file",
+		},
+		{
+			Destination: "/etc/bar",
+			Type:        "dir",
+		},
+		{
+			Destination: "/etc/baz",
+			Type:        "dir",
+			FileInfo: &files.ContentFileInfo{
+				Owner: "test",
+				Mode:  0o700,
+			},
+		},
+	}
+
+	var rpmFileBuffer bytes.Buffer
+	err := Default.Package(info, &rpmFileBuffer)
+	require.NoError(t, err)
+
+	// the directory /etc/foo should not be implicitly created as that
+	// implies ownership of /etc/foo which should always be implicit
+	_, err = extractFileHeaderFromRpm(rpmFileBuffer.Bytes(), "/etc/foo")
+	require.Equal(t, err, os.ErrNotExist)
+
+	// claiming explicit ownership of /etc/bar which already contains a file
+	h, err := extractFileHeaderFromRpm(rpmFileBuffer.Bytes(), "/etc/bar")
+	require.NoError(t, err)
+	require.NotEqual(t, h.Mode()&int(rpmDirectoryFlag), 0)
+
+	// creating an empty folder (which also implies ownership)
+	h, err = extractFileHeaderFromRpm(rpmFileBuffer.Bytes(), "/etc/baz")
+	require.NoError(t, err)
+	require.Equal(t, h.Mode(), int(rpmDirectoryFlag|0o700))
 }
 
 func extractFileFromRpm(rpm []byte, filename string) ([]byte, error) {

--- a/testdata/acceptance/rpm.directories.yaml
+++ b/testdata/acceptance/rpm.directories.yaml
@@ -1,0 +1,24 @@
+name: "foo"
+arch: "${BUILD_ARCH}"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+release: "4"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+contents:
+  - src: ./testdata/fake
+    dst: /etc/foo/file
+  - src: ./testdata/fake
+    dst: /etc/bar/file
+  - dst: /etc/bar
+    type: dir
+  - dst: /etc/baz
+    type: dir
+    file_info:
+      mode: 0700
+      group: test

--- a/testdata/acceptance/rpm.dockerfile
+++ b/testdata/acceptance/rpm.dockerfile
@@ -195,3 +195,19 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN rpm -e foo
 RUN test -f /etc/foo/whatever.conf.rpmsave
 RUN test ! -f /usr/local/bin/fake
+
+# ---- directories test ----
+FROM test_base AS directories
+RUN groupadd test
+RUN rpm -ivh /tmp/foo.rpm
+RUN test -f /etc/foo/file
+RUN test -f /etc/bar/file
+RUN test -d /etc/bar
+RUN test -d /etc/baz
+RUN stat -L -c "%a %U %G" /etc/baz | grep "700 root test"
+RUN rpm -e foo
+RUN test ! -f /etc/foo/file
+RUN test ! -f /etc/bar/file
+RUN test -d /etc/foo
+RUN test ! -d /etc/bar
+RUN test ! -d /etc/baz

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -171,6 +171,16 @@ contents:
       owner: notRoot
       group: notRoot
 
+  # Using the type 'dir', empty directories can be created. When building RPMs, however, this
+  # type has another important purpose: Claiming ownership of that folder. This is important
+  # because when upgrading or removing an RPM package, only the directories for which it has
+  # claimed ownership are removed. However, you should not claim ownership of a folder that
+  # is created by the distro or a dependency of your package.
+  - dst: /some/dir
+    type: dir
+    file_info:
+      mode: 0700
+
 # Empty folders your package may need created. (overridable)
 empty_folders:
   - /var/log/foo

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -179,6 +179,8 @@ contents:
   # because when upgrading or removing an RPM package, only the directories for which it has
   # claimed ownership are removed. However, you should not claim ownership of a folder that
   # is created by the distro or a dependency of your package.
+  # A directory in the build environment can optionally be provided in the 'src' field in
+  # order copy mtime and mode from that directory without having to specifiy it manually.
   - dst: /some/dir
     type: dir
     file_info:

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -53,8 +53,7 @@ priority: extra
 
 # Maintainer.
 # Defaults to empty on rpm and apk
-# Leaving this field empty on 'deb' packages is deprecated, and will be removed
-# in a future release
+# Leaving the 'maintainer' field unset will not be allowed in a future version
 maintainer: Carlos Alexandro Becker <root@carlosbecker.com>
 
 # Description.

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -164,7 +164,9 @@ contents:
     packager: apk
 
   # Sometimes it is important to be able to set the mtime, mode, owner, or group for a file
-  # that differs from what is on the local build system at build time.
+  # that differs from what is on the local build system at build time. The owner (if different
+  # than 'root') has to be always specified manually in 'file_info' as it will not be copied
+  # from the 'src' file.
   - src: path/to/foo
     dst: /usr/local/foo
     file_info:


### PR DESCRIPTION
This PR introduces the content type `dir` which can be used to add empty directories or directories with custom attributes such as owner, group or permissions. It also makes `EmptyFolders` obsolete.

Another important aspect is that it can be used to specified directories "owned" by the package when packaging RPMs as only those directories are removed when the package is uninstalled. This use case is also now well documented.