### PR TITLE
fix docker exec example

### DIFF
--- a/www/docs/install.md
+++ b/www/docs/install.md
@@ -109,7 +109,7 @@ You can also use it within a Docker container. To do that, you'll need to
 execute something more-or-less like the following:
 
 ```sh
-docker run --rm -v $PWD:/tmp/pkg goreleaser/nfpm package \
+docker run --rm -v $PWD:/tmp -w /tmp goreleaser/nfpm package \
 	--config /tmp/pkg/foo.yml \
 	--target /tmp \
 	--packager deb


### PR DESCRIPTION
Hi

1. looks like the $PWD should be bind mounted as `/tmp`, otherwise the `/tmp` won't be visible on the host system
2. I set the container workdir to `tmp` so that the relative paths in foo.yml can be resolved