### PR TITLE
Fix: Allow complex file modes for debs and apks.

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -471,6 +471,9 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, sizep *int64) error
 		return err
 	}
 
+	// tar.FileInfoHeader only uses file.Mode().Perm() which masks the mode with
+	// 0o777 which we don't want because we want to be able to set the suid bit.
+	header.Mode = int64(file.Mode())
 	header.Name = files.ToNixPath(file.Destination[1:])
 	header.Uname = file.FileInfo.Owner
 	header.Gname = file.FileInfo.Group

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -343,6 +343,10 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, md5w io.Writer) (in
 		log.Print(err)
 		return 0, err
 	}
+
+	// tar.FileInfoHeader only uses file.Mode().Perm() which masks the mode with
+	// 0o777 which we don't want because we want to be able to set the suid bit.
+	header.Mode = int64(file.Mode())
 	header.Format = tar.FormatGNU
 	header.Name = normalizePath(file.Destination)
 	header.Uname = file.FileInfo.Owner

--- a/testdata/acceptance/apk.dockerfile
+++ b/testdata/acceptance/apk.dockerfile
@@ -47,6 +47,7 @@ RUN test -f /usr/share/whatever/folder/folder2/file1
 RUN test -f /usr/share/whatever/folder/folder2/file2
 RUN test -d /var/log/whatever
 RUN test -d /usr/share/foo
+RUN test $(stat -c %a /usr/sbin/fake) -eq 4755
 RUN test -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
 RUN test ! -f /tmp/preremove-proof
@@ -55,6 +56,7 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN apk del foo
 RUN test -f /etc/foo/whatever.conf
 RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/sbin/fake
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
 RUN test ! -d /var/log/whatever

--- a/testdata/acceptance/core.complex.yaml
+++ b/testdata/acceptance/core.complex.yaml
@@ -27,6 +27,10 @@ contents:
 - src: ./testdata/whatever.conf
   dst: /etc/foo/whatever.conf
   type: config
+- src: ./testdata/fake
+  dst: /usr/sbin/fake
+  file_info:
+    mode: 04755
 empty_folders:
 - /var/log/whatever
 - /usr/share/foo

--- a/testdata/acceptance/deb.dockerfile
+++ b/testdata/acceptance/deb.dockerfile
@@ -50,6 +50,7 @@ RUN test -f /usr/share/whatever/folder/folder2/file1
 RUN test -f /usr/share/whatever/folder/folder2/file2
 RUN test -d /var/log/whatever
 RUN test -d /usr/share/foo
+RUN test $(stat -c %a /usr/sbin/fake) -eq 4755
 RUN test -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
 RUN test ! -f /tmp/preremove-proof
@@ -58,11 +59,11 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN dpkg -r foo
 RUN test -f /etc/foo/whatever.conf
 RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/sbin/fake
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
 RUN test ! -d /var/log/whatever
 RUN test ! -d /usr/share/foo
-
 
 # ---- signed test ----
 FROM test_base AS signed

--- a/testdata/acceptance/rpm.dockerfile
+++ b/testdata/acceptance/rpm.dockerfile
@@ -49,6 +49,7 @@ RUN test -f /usr/share/whatever/folder/folder2/file1
 RUN test -f /usr/share/whatever/folder/folder2/file2
 RUN test -d /var/log/whatever
 RUN test -d /usr/share/foo
+RUN test $(stat -c %a /usr/sbin/fake) -eq 4755
 RUN test -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
 RUN test -f /tmp/pretrans-proof
@@ -59,6 +60,7 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN rpm -e foo
 RUN test -f /etc/foo/whatever.conf.rpmsave
 RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/sbin/fake
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
 RUN test ! -d /var/log/whatever

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -166,6 +166,7 @@ contents:
   - src: path/to/foo
     dst: /usr/local/foo
     file_info:
+      # Make sure that the mode is specified in octal, e.g. 0644 instead of 644.
       mode: 0644
       mtime: 2008-01-02T15:04:05Z
       owner: notRoot


### PR DESCRIPTION
This PRs fixes #392 by passing the full file mode instead of just the permissions (which is the mode masked with `0o777`) to the `tar` header. It also added acceptance tests with suid bit for all packagers and documentation that reminds users to specify the mode in octal.