### PR TITLE
Feature: Allow platform specific arch overrides.

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -103,13 +103,15 @@ func (a *Apk) ConventionalFileName(info *nfpm.Info) string {
 
 // Package writes a new apk package to the given writer using the given info.
 func (*Apk) Package(info *nfpm.Info, apk io.Writer) (err error) {
-	arch, ok := archToAlpine[info.Arch]
-	if ok {
-		info.Arch = arch
+	if info.APK.APKArch != "" {
+		info.Arch = info.APK.APKArch
+	} else {
+		arch, ok := archToAlpine[info.Arch]
+		if ok {
+			info.Arch = arch
+		}
 	}
-	if info.Arch == "" {
-		info.Arch = archToAlpine["amd64"]
-	}
+
 	if err = info.Validate(); err != nil {
 		return err
 	}

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -84,7 +84,6 @@ func exampleInfo() *nfpm.Info {
 }
 
 func TestArchToAlpine(t *testing.T) {
-	verifyArch(t, "", "x86_64")
 	verifyArch(t, "abc", "abc")
 	verifyArch(t, "386", "x86")
 	verifyArch(t, "amd64", "x86_64")

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -82,10 +82,15 @@ var ErrInvalidSignatureType = errors.New("invalid signature type")
 
 // Package writes a new deb package to the given writer using the given info.
 func (d *Deb) Package(info *nfpm.Info, deb io.Writer) (err error) { // nolint: funlen
-	arch, ok := archToDebian[info.Arch]
-	if ok {
-		info.Arch = arch
+	if info.Deb.DebArch != "" {
+		info.Arch = info.Deb.DebArch
+	} else {
+		arch, ok := archToDebian[info.Arch]
+		if ok {
+			info.Arch = arch
+		}
 	}
+
 	if err = info.Validate(); err != nil {
 		return err
 	}

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -43,6 +43,19 @@ var archToDebian = map[string]string{
 	"ppc64le": "ppc64el",
 }
 
+func ensureValidArch(info *nfpm.Info) *nfpm.Info {
+	if info.Deb.Arch != "" {
+		info.Arch = info.Deb.Arch
+	} else {
+		arch, ok := archToDebian[info.Arch]
+		if ok {
+			info.Arch = arch
+		}
+	}
+
+	return info
+}
+
 // Default deb packager.
 // nolint: gochecknoglobals
 var Default = &Deb{}
@@ -54,10 +67,7 @@ type Deb struct{}
 // to the conventions for debian packages. See:
 // https://manpages.debian.org/buster/dpkg-dev/dpkg-name.1.en.html
 func (*Deb) ConventionalFileName(info *nfpm.Info) string {
-	arch, ok := archToDebian[info.Arch]
-	if !ok {
-		arch = info.Arch
-	}
+	info = ensureValidArch(info)
 
 	version := info.Version
 	if info.Prerelease != "" {
@@ -73,7 +83,7 @@ func (*Deb) ConventionalFileName(info *nfpm.Info) string {
 	}
 
 	// package_version_architecture.package-type
-	return fmt.Sprintf("%s_%s_%s.deb", info.Name, version, arch)
+	return fmt.Sprintf("%s_%s_%s.deb", info.Name, version, info.Arch)
 }
 
 // ErrInvalidSignatureType happens if the signature type of a deb is not one of
@@ -82,15 +92,7 @@ var ErrInvalidSignatureType = errors.New("invalid signature type")
 
 // Package writes a new deb package to the given writer using the given info.
 func (d *Deb) Package(info *nfpm.Info, deb io.Writer) (err error) { // nolint: funlen
-	if info.Deb.DebArch != "" {
-		info.Arch = info.Deb.DebArch
-	} else {
-		arch, ok := archToDebian[info.Arch]
-		if ok {
-			info.Arch = arch
-		}
-	}
-
+	info = ensureValidArch(info)
 	if err = info.Validate(); err != nil {
 		return err
 	}

--- a/nfpm.go
+++ b/nfpm.go
@@ -263,7 +263,7 @@ type Overridables struct {
 
 // RPM is custom configs that are only available on RPM packages.
 type RPM struct {
-	RPMArch     string       `yaml:"rpm_arch,omitempty" jsonschema:"title=architecture in rpm nomenclature"`
+	Arch        string       `yaml:"arch,omitempty" jsonschema:"title=architecture in rpm nomenclature"`
 	Scripts     RPMScripts   `yaml:"scripts,omitempty" jsonschema:"title=rpm-specific scripts"`
 	Group       string       `yaml:"group,omitempty" jsonschema:"title=package group,example=Unspecified"`
 	Summary     string       `yaml:"summary,omitempty" jsonschema:"title=package summary"`
@@ -289,7 +289,7 @@ type RPMSignature struct {
 }
 
 type APK struct {
-	APKArch   string       `yaml:"apk_arch,omitempty" jsonschema:"title=architecture in apk nomenclature"`
+	Arch      string       `yaml:"arch,omitempty" jsonschema:"title=architecture in apk nomenclature"`
 	Signature APKSignature `yaml:"signature,omitempty" jsonschema:"title=apk signature"`
 	Scripts   APKScripts   `yaml:"scripts,omitempty" jsonschema:"title=apk scripts"`
 }
@@ -307,7 +307,7 @@ type APKScripts struct {
 
 // Deb is custom configs that are only available on deb packages.
 type Deb struct {
-	DebArch     string       `yaml:"deb_arch,omitempty" jsonschema:"title=architecture in deb nomenclature"`
+	Arch        string       `yaml:"arch,omitempty" jsonschema:"title=architecture in deb nomenclature"`
 	Scripts     DebScripts   `yaml:"scripts,omitempty" jsonschema:"title=scripts"`
 	Triggers    DebTriggers  `yaml:"triggers,omitempty" jsonschema:"title=triggers"`
 	Breaks      []string     `yaml:"breaks,omitempty" jsonschema:"title=breaks"`
@@ -362,7 +362,7 @@ func Validate(info *Info) (err error) {
 	if info.Name == "" {
 		return ErrFieldEmpty{"name"}
 	}
-	if info.Arch == "" {
+	if info.Arch == "" && (info.Deb.Arch == "" || info.RPM.Arch == "" || info.APK.Arch == "") {
 		return ErrFieldEmpty{"arch"}
 	}
 	if info.Version == "" {

--- a/nfpm.go
+++ b/nfpm.go
@@ -263,6 +263,7 @@ type Overridables struct {
 
 // RPM is custom configs that are only available on RPM packages.
 type RPM struct {
+	RPMArch     string       `yaml:"rpm_arch,omitempty" jsonschema:"title=architecture in rpm nomenclature"`
 	Scripts     RPMScripts   `yaml:"scripts,omitempty" jsonschema:"title=rpm-specific scripts"`
 	Group       string       `yaml:"group,omitempty" jsonschema:"title=package group,example=Unspecified"`
 	Summary     string       `yaml:"summary,omitempty" jsonschema:"title=package summary"`
@@ -288,6 +289,7 @@ type RPMSignature struct {
 }
 
 type APK struct {
+	APKArch   string       `yaml:"apk_arch,omitempty" jsonschema:"title=architecture in apk nomenclature"`
 	Signature APKSignature `yaml:"signature,omitempty" jsonschema:"title=apk signature"`
 	Scripts   APKScripts   `yaml:"scripts,omitempty" jsonschema:"title=apk scripts"`
 }
@@ -305,6 +307,7 @@ type APKScripts struct {
 
 // Deb is custom configs that are only available on deb packages.
 type Deb struct {
+	DebArch     string       `yaml:"deb_arch,omitempty" jsonschema:"title=architecture in deb nomenclature"`
 	Scripts     DebScripts   `yaml:"scripts,omitempty" jsonschema:"title=scripts"`
 	Triggers    DebTriggers  `yaml:"triggers,omitempty" jsonschema:"title=triggers"`
 	Breaks      []string     `yaml:"breaks,omitempty" jsonschema:"title=breaks"`

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -61,8 +61,8 @@ var archToRPM = map[string]string{
 }
 
 func ensureValidArch(info *nfpm.Info) *nfpm.Info {
-	if info.APK.APKArch != "" {
-		info.Arch = info.APK.APKArch
+	if info.RPM.Arch != "" {
+		info.Arch = info.RPM.Arch
 	} else {
 		arch, ok := archToRPM[info.Arch]
 		if ok {

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -61,10 +61,15 @@ var archToRPM = map[string]string{
 }
 
 func ensureValidArch(info *nfpm.Info) *nfpm.Info {
-	arch, ok := archToRPM[info.Arch]
-	if ok {
-		info.Arch = arch
+	if info.APK.APKArch != "" {
+		info.Arch = info.APK.APKArch
+	} else {
+		arch, ok := archToRPM[info.Arch]
+		if ok {
+			info.Arch = arch
+		}
 	}
+
 	return info
 }
 

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -10,6 +10,9 @@ name: foo
 
 # Architecture. (required)
 # This will expand any env var you set in the field, eg version: ${GOARCH}
+# The architecture is specified using Go nomenclature (GOARCH) and translated
+# to the platform specific equivalent. In order to manually set the architecture
+# to a platform specific value, use deb_arch, rpm_arch and apk_arch.
 arch: amd64
 
 # Platform.
@@ -201,6 +204,9 @@ overrides:
 
 # Custom configuration applied only to the RPM packager.
 rpm:
+  # rpm specific architecture name that overrides "arch" without performing any replacements.
+  rpm_arch: ia64
+
   # RPM specific scripts.
   scripts:
     # The pretrans script runs before all RPM package transactions / stages.
@@ -234,6 +240,9 @@ rpm:
 
 # Custom configuration applied only to the Deb packager.
 deb:
+  # deb specific architecture name that overrides "arch" without performing any replacements.
+  deb_arch: arm
+
   # Custom deb special files.
   scripts:
     # Deb rules script.
@@ -279,6 +288,9 @@ deb:
     key_id: bc8acdd415bd80b3
 
 apk:
+  # apk specific architecture name that overrides "arch" without performing any replacements.
+  apk_arch: armhf
+
   # The package is signed if a key_file is set
   signature:
     # RSA private key in the PEM format. The passphrase is taken from


### PR DESCRIPTION
This PR fixes #367 by allowing platform specific arch overrides. The documentation now also clarifies that the `arch` field is translated and references the override options.

I also removed `arch` defaulting to `amd64` for APKs as it was not consistent with the other packagers and it should be specified in any case in order to avoid invalid packages (`amd64` packages without `amd64` specific contents or with an `arm` binary).