### PR TITLE
feat: expand-env support for vendor field

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -154,6 +154,9 @@ func (c *Config) expandEnvVars() {
 	c.Info.Prerelease = os.Expand(c.Info.Prerelease, c.envMappingFunc)
 	c.Info.Arch = os.Expand(c.Info.Arch, c.envMappingFunc)
 
+	// Vendor field
+	c.Info.Vendor = os.Expand(c.Info.Vendor, c.envMappingFunc)
+
 	// Package signing related fields
 	c.Info.Deb.Signature.KeyFile = os.Expand(c.Deb.Signature.KeyFile, c.envMappingFunc)
 	c.Info.RPM.Signature.KeyFile = os.Expand(c.RPM.Signature.KeyFile, c.envMappingFunc)

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -243,6 +243,7 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		apkPass    = "foobar"
 		release    = "3"
 		version    = "1.0.0"
+		vendor     = "GoReleaser"
 	)
 
 	t.Run("version", func(t *testing.T) {
@@ -259,6 +260,14 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		info, err := nfpm.Parse(strings.NewReader("name: foo\nrelease: $RELEASE"))
 		require.NoError(t, err)
 		require.Equal(t, release, info.Release)
+	})
+
+	t.Run("vendor", func(t *testing.T) {
+		os.Clearenv()
+		os.Setenv("VENDOR", vendor)
+		info, err := nfpm.Parse(strings.NewReader("name: foo\nvendor: $VENDOR"))
+		require.NoError(t, err)
+		require.Equal(t, vendor, info.Vendor)
 	})
 
 	t.Run("global passphrase", func(t *testing.T) {

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -64,6 +64,7 @@ maintainer: Carlos Alexandro Becker <root@carlosbecker.com>
 description: Sample package
 
 # Vendor.
+# This will expand any env var you set in the field, eg vendor: ${VENDOR}
 vendor: GoReleaser
 
 # Package's homepage.


### PR DESCRIPTION
This PR allows to expand env for vendor field. This can be useful if another entity wants to redistribute a package.