### PR TITLE
feat: custom packager configuration for rpm pkg

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -185,6 +185,9 @@ func (c *Config) expandEnvVars() {
 	if apkPassphrase != "" {
 		c.Info.APK.Signature.KeyPassphrase = apkPassphrase
 	}
+
+	// RPM specific
+	c.Info.RPM.Packager = os.Expand(c.RPM.Packager, c.envMappingFunc)
 }
 
 // Info contains information about a single package.
@@ -273,6 +276,7 @@ type RPM struct {
 	Summary     string       `yaml:"summary,omitempty" jsonschema:"title=package summary"`
 	Compression string       `yaml:"compression,omitempty" jsonschema:"title=compression algorithm to be used,enum=gzip,enum=lzma,enum=xz,default=gzip"`
 	Signature   RPMSignature `yaml:"signature,omitempty" jsonschema:"title=rpm signature"`
+	Packager    string       `yaml:"packager,omitempty" jsonschema:"title=organization that actually packaged the software"`
 }
 
 // RPMScripts represents scripts only available on RPM packages.

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -244,6 +244,7 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		release    = "3"
 		version    = "1.0.0"
 		vendor     = "GoReleaser"
+		packager   = "nope"
 	)
 
 	t.Run("version", func(t *testing.T) {
@@ -291,6 +292,14 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		require.Equal(t, debPass, info.Deb.Signature.KeyPassphrase)
 		require.Equal(t, rpmPass, info.RPM.Signature.KeyPassphrase)
 		require.Equal(t, apkPass, info.APK.Signature.KeyPassphrase)
+	})
+
+	t.Run("packager", func(t *testing.T) {
+		os.Clearenv()
+		os.Setenv("PACKAGER", packager)
+		info, err := nfpm.Parse(strings.NewReader("name: foo\nrpm:\n  packager: $PACKAGER"))
+		require.NoError(t, err)
+		require.Equal(t, packager, info.RPM.Packager)
 	})
 }
 

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -228,7 +228,7 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		Licence:     info.License,
 		URL:         info.Homepage,
 		Vendor:      info.Vendor,
-		Packager:    info.Maintainer,
+		Packager:    defaultTo(info.RPM.Packager, info.Maintainer),
 		Group:       info.RPM.Group,
 		Provides:    provides,
 		Recommends:  recommends,

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -183,6 +183,33 @@ func TestRPMSummary(t *testing.T) {
 	require.Equal(t, customSummary, summary)
 }
 
+func TestRPMPackager(t *testing.T) {
+	f, err := ioutil.TempFile("", "test.rpm")
+	require.NoError(t, err)
+
+	customPackager := "GoReleaser <staff@goreleaser.com>"
+	info := exampleInfo()
+	info.RPM.Group = "Unspecified"
+	info.RPM.Packager = customPackager
+
+	require.NoError(t, Default.Package(info, f))
+
+	file, err := os.OpenFile(f.Name(), os.O_RDONLY, 0o600) //nolint:gosec
+	require.NoError(t, err)
+	defer func() {
+		f.Close()
+		file.Close()
+		err = os.Remove(file.Name())
+		require.NoError(t, err)
+	}()
+	rpm, err := rpmutils.ReadRpm(file)
+	require.NoError(t, err)
+
+	packager, err := rpm.Header.GetString(rpmutils.PACKAGER)
+	require.NoError(t, err)
+	require.Equal(t, customPackager, packager)
+}
+
 func TestWithRPMTags(t *testing.T) {
 	f, err := ioutil.TempFile("", "test.rpm")
 	require.NoError(t, err)

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -233,6 +233,12 @@ rpm:
   # description, but can be explicitly provided here.
   summary: Explicit Summary for Sample Package
 
+  # The packager is used to identify the organization that actually packaged
+  # the software, as opposed to the author of the software.
+  # `maintainer` will be used as fallback if not specified.
+  # This will expand any env var you set in the field, eg packager: ${PACKAGER}
+  packager: GoReleaser <staff@goreleaser.com>
+
   # Compression algorithm (gzip (default), lzma or xz).
   compression: lzma
 


### PR DESCRIPTION
Atm rpm `Packager` uses the maintainer value which is sometimes not true when another entity wants to redistribute a package:

> ```
> #
> # Example spec file for cdplayer app...
> #
> Summary: A CD player app that rocks!
> Name: cdplayer
> Version: 1.0
> Release: 1
> License: GPL
> Group: Applications/Sound
> Source: ftp://ftp.gnomovision.com/pub/cdplayer/cdplayer-1.0.tgz
> URL: http://www.gnomovision.com/cdplayer/cdplayer.html
> Distribution: WSS Linux
> Vendor: White Socks Software, Inc.
> Packager: Santa Claus <sclaus@northpole.com>
> 
> %description
> It slices!  It dices!  It's a CD player app that
> can't be beat.  By using the resonant frequency
> of the CD itself, it is able to simulate 20X
> oversampling.  This leads to sound quality that
> cannot be equaled with more mundane software...
> ```
>
> The **vendor** line identifies the organization that distributes the software. Maintaining our fictional motif, we've invented fictional company, White Socks Software, to add to our spec file. Individuals will probably omit this as well. 
>
> The **packager** line is used to identify the organization that actually packaged the software, as opposed to the author of the software. In our example, we've chosen the greatest packager of them all, Santa Claus, to work at White Socks Software. Note that we've included contact information, in the form of an e-mail address.

This PR allows to customize this field and also to expand env var for it.