### PR TITLE
fix: Prevent duplicate folders from being created.

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -489,7 +489,7 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, sizep *int64) error
 	// tar.FileInfoHeader only uses file.Mode().Perm() which masks the mode with
 	// 0o777 which we don't want because we want to be able to set the suid bit.
 	header.Mode = int64(file.Mode())
-	header.Name = normalizePath(file.Destination[1:])
+	header.Name = normalizePath(file.Destination)
 	header.Uname = file.FileInfo.Owner
 	header.Gname = file.FileInfo.Group
 	if err = newItemInsideTarGz(tw, contents, header); err != nil {
@@ -500,10 +500,9 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, sizep *int64) error
 	return nil
 }
 
-// normalizePath returns a path separated by slashes, all relative path items
-// resolved and relative to the current directory (so it starts with "./").
+// normalizePath returns a path separated by slashes without a leading slash.
 func normalizePath(src string) string {
-	return "." + files.ToNixPath(filepath.Join("/", src))
+	return files.ToNixPath(strings.TrimLeft(src, "/"))
 }
 
 // this is needed because the data.tar.gz file should have the empty folders

--- a/apk/apk.go
+++ b/apk/apk.go
@@ -414,8 +414,14 @@ func createFilesInsideTarGz(info *nfpm.Info, tw *tar.Writer, created map[string]
 			continue
 		}
 
+		normalizedName := normalizePath(strings.Trim(file.Destination, "/")) + "/"
+
+		if created[normalizedName] {
+			return fmt.Errorf("duplicate directory: %q", normalizedName)
+		}
+
 		err = tw.WriteHeader(&tar.Header{
-			Name:     files.ToNixPath(strings.Trim(file.Destination, "/") + "/"),
+			Name:     normalizedName,
 			Mode:     int64(file.FileInfo.Mode),
 			Typeflag: tar.TypeDir,
 			Format:   tar.FormatGNU,
@@ -427,7 +433,7 @@ func createFilesInsideTarGz(info *nfpm.Info, tw *tar.Writer, created map[string]
 			return err
 		}
 
-		created[strings.TrimPrefix(file.Destination, "/")] = true
+		created[normalizedName] = true
 	}
 
 	for _, file := range info.Contents {
@@ -483,7 +489,7 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, sizep *int64) error
 	// tar.FileInfoHeader only uses file.Mode().Perm() which masks the mode with
 	// 0o777 which we don't want because we want to be able to set the suid bit.
 	header.Mode = int64(file.Mode())
-	header.Name = files.ToNixPath(file.Destination[1:])
+	header.Name = normalizePath(file.Destination[1:])
 	header.Uname = file.FileInfo.Owner
 	header.Gname = file.FileInfo.Group
 	if err = newItemInsideTarGz(tw, contents, header); err != nil {
@@ -494,20 +500,31 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, sizep *int64) error
 	return nil
 }
 
+// normalizePath returns a path separated by slashes, all relative path items
+// resolved and relative to the current directory (so it starts with "./").
+func normalizePath(src string) string {
+	return "." + files.ToNixPath(filepath.Join("/", src))
+}
+
 // this is needed because the data.tar.gz file should have the empty folders
 // as well, so we walk through the dst and create all subfolders.
 func createTree(tarw *tar.Writer, dst string, created map[string]bool) error {
 	for _, path := range pathsToCreate(dst) {
+		path = normalizePath(path) + "/"
+
 		if created[path] {
 			// skipping dir that was previously created inside the archive
 			// (eg: usr/)
 			continue
 		}
+
 		if err := tarw.WriteHeader(&tar.Header{
-			Name:     files.ToNixPath(path + "/"),
+			Name:     path,
 			Mode:     0o755,
 			Typeflag: tar.TypeDir,
 			Format:   tar.FormatGNU,
+			Uname:    "root",
+			Gname:    "root",
 		}); err != nil {
 			return fmt.Errorf("failed to create folder %s: %w", path, err)
 		}

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -132,9 +132,9 @@ func TestPathsToCreate(t *testing.T) {
 
 func TestDefaultWithArch(t *testing.T) {
 	expectedChecksums := map[string]string{
-		"./usr/share/doc/fake/fake.txt": "96c335dc28122b5f09a4cef74b156cd24c23784c",
-		"./usr/local/bin/fake":          "f46cece3eeb7d9ed5cb244d902775427be71492d",
-		"./etc/fake/fake.conf":          "96c335dc28122b5f09a4cef74b156cd24c23784c",
+		"usr/share/doc/fake/fake.txt": "96c335dc28122b5f09a4cef74b156cd24c23784c",
+		"usr/local/bin/fake":          "f46cece3eeb7d9ed5cb244d902775427be71492d",
+		"etc/fake/fake.conf":          "96c335dc28122b5f09a4cef74b156cd24c23784c",
 	}
 	for _, arch := range []string{"386", "amd64"} {
 		arch := arch
@@ -379,7 +379,7 @@ func TestDisableGlobbing(t *testing.T) {
 	dataTar, err := ioutil.ReadAll(gzr)
 	require.NoError(t, err)
 
-	extractedContent := extractFromTar(t, dataTar, "./test/{file}[")
+	extractedContent := extractFromTar(t, dataTar, "test/{file}[")
 	actualContent, err := ioutil.ReadFile("../testdata/{file}[")
 	require.NoError(t, err)
 	require.Equal(t, actualContent, extractedContent)
@@ -551,9 +551,9 @@ func TestNoDuplicateAutocreatedDirectories(t *testing.T) {
 	require.NoError(t, info.Validate())
 
 	expected := map[string]bool{
-		"./etc/":        true,
-		"./etc/foo/":    true,
-		"./etc/foo/bar": true,
+		"etc/":        true,
+		"etc/foo/":    true,
+		"etc/foo/bar": true,
 	}
 
 	var buf bytes.Buffer

--- a/files/files.go
+++ b/files/files.go
@@ -205,8 +205,13 @@ func checkNoCollisions(contents Contents) error {
 	for _, elem := range contents {
 		present, ok := alreadyPresent[elem.Destination]
 		if ok && (present.Packager == "" || elem.Packager == "" || present.Packager == elem.Packager) {
+			if elem.Type == "dir" {
+				return fmt.Errorf("cannot add directory %q because it is already present: %w",
+					elem.Destination, ErrContentCollision)
+			}
+
 			return fmt.Errorf(
-				"cannot add %s because %s is already present at the same destination (%s): %w",
+				"cannot add %q because %q is already present at the same destination (%s): %w",
 				elem.Source, present.Source, present.Destination, ErrContentCollision)
 		}
 


### PR DESCRIPTION
Currently a package can contain duplicate folders depending on the way a user specified a dir-type content destination (folder name). This PR fixes that by keeping track of created folders in the already existing `created` map with a **consistent naming convention**. It also adds related tests.

Another bug that's also fixed by this PR is that auto-created folders did not have a owner username and group name.