### PR TITLE
fix: disable debian arm6 tests

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -21,7 +21,7 @@ import (
 // nolint: gochecknoglobals
 var formatArchs = map[string][]string{
 	"apk": {"amd64", "arm64", "386", "ppc64le", "armv6", "armv7", "s390x"},
-	"deb": {"amd64", "arm64", "ppc64le", "armv6", "armv7", "s390x"},
+	"deb": {"amd64", "arm64", "ppc64le", "armv7", "s390x"},
 	"rpm": {"amd64", "arm64", "ppc64le", "armv7"},
 }
 


### PR DESCRIPTION
shouldn't have merged https://github.com/goreleaser/nfpm/pull/412

problem is when you request debian linux/arm/6, the arm7 image is given...

```sh
docker run --platform linux/arm/6 --rm  debian uname -a
```

it was working before because our test was wrong (arch was arm7 and testing against a arm7, thinking it was arm6)