### PR TITLE
chore(Taskfile): Remove -s flag for gofumpt

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,7 +67,7 @@ tasks:
   fmt:
     desc: gofumpt all code
     cmds:
-      - gofumpt -w -l -s .
+      - gofumpt -w -l .
 
   ci:
     desc: Run all CI steps


### PR DESCRIPTION
version v0.2.0 has removed the -s flag.

It is now always on.

https://github.com/mvdan/gofumpt/releases/tag/v0.2.0

fixes  #420