### PR TITLE
Test: more generic tests.

### DIFF
--- a/testdata/acceptance/core.epoch.yaml
+++ b/testdata/acceptance/core.epoch.yaml
@@ -1,0 +1,10 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+epoch: 2
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/local/bin/fake

--- a/testdata/acceptance/core.file-twice.yaml
+++ b/testdata/acceptance/core.file-twice.yaml
@@ -11,6 +11,5 @@ release: "symlink"
 contents:
   - src: ./testdata/whatever.conf
     dst: /etc/foo/whatever.conf
-  - src: /etc/foo/whatever.conf
-    dst: /path/to/symlink
-    type: symlink
+  - src: ./testdata/whatever.conf
+    dst: /etc/foo/whatever.conf

--- a/testdata/acceptance/core.filename-longer-256.yaml
+++ b/testdata/acceptance/core.filename-longer-256.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/verryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyloooooooooooooooooooooooooooooooooooooooooooooooooooooooongfilename123456780000000000000000000000000000000000000000000000000000000000

--- a/testdata/acceptance/core.filename-with-leading-whitespace.yaml
+++ b/testdata/acceptance/core.filename-with-leading-whitespace.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: "/usr/ filename"

--- a/testdata/acceptance/core.filename-with-newline.yaml
+++ b/testdata/acceptance/core.filename-with-newline.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: "/usr/file\nname"

--- a/testdata/acceptance/core.filename-with-null.yaml
+++ b/testdata/acceptance/core.filename-with-null.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: "/usr/file\0name"

--- a/testdata/acceptance/core.filename-with-whitespace.yaml
+++ b/testdata/acceptance/core.filename-with-whitespace.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: "/usr/file name"

--- a/testdata/acceptance/core.folder.yaml
+++ b/testdata/acceptance/core.folder.yaml
@@ -7,10 +7,7 @@ maintainer: "Foo Bar"
 vendor: "foobar"
 homepage: "https://foobar.org"
 license: "MIT"
-release: "symlink"
+release: "folder"
 contents:
-  - src: ./testdata/whatever.conf
-    dst: /etc/foo/whatever.conf
-  - src: /etc/foo/whatever.conf
-    dst: /path/to/symlink
-    type: symlink
+  - dst: /path/to/folder
+    type: dir

--- a/testdata/acceptance/core.long-path-256.yaml
+++ b/testdata/acceptance/core.long-path-256.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/verryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/loooooooooooooooooooooooooooooooooooooooooooooooooooooooong/paaaaaaaaaaaaaaaaaaaaaaaaathhhhhhh/bin/fake

--- a/testdata/acceptance/core.path-with-dotdot-escape-2.yaml
+++ b/testdata/acceptance/core.path-with-dotdot-escape-2.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: /../../usr/bin/fake

--- a/testdata/acceptance/core.path-with-dotdot-escape.yaml
+++ b/testdata/acceptance/core.path-with-dotdot-escape.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ../go.mod
+    dst: /usr/bin/fake

--- a/testdata/acceptance/core.path-with-windows-c-seperator.yaml
+++ b/testdata/acceptance/core.path-with-windows-c-seperator.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: C:\Folder\filename

--- a/testdata/acceptance/core.path-with-windows-seperator.yaml
+++ b/testdata/acceptance/core.path-with-windows-seperator.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: \Folder\filename

--- a/testdata/acceptance/core.symlink-broken.yaml
+++ b/testdata/acceptance/core.symlink-broken.yaml
@@ -9,8 +9,6 @@ homepage: "https://foobar.org"
 license: "MIT"
 release: "symlink"
 contents:
-  - src: ./testdata/whatever.conf
-    dst: /etc/foo/whatever.conf
   - src: /etc/foo/whatever.conf
     dst: /path/to/symlink
     type: symlink

--- a/testdata/acceptance/core.unclean-path-1.yaml
+++ b/testdata/acceptance/core.unclean-path-1.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/local/bin/../fake

--- a/testdata/acceptance/core.unclean-path-2.yaml
+++ b/testdata/acceptance/core.unclean-path-2.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/local/../../fake

--- a/testdata/acceptance/core.unclean-path-3.yaml
+++ b/testdata/acceptance/core.unclean-path-3.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/./bin/fake

--- a/testdata/acceptance/core.unclean-path-4.yaml
+++ b/testdata/acceptance/core.unclean-path-4.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/////bin/fake

--- a/testdata/acceptance/core.unclean-path-5.yaml
+++ b/testdata/acceptance/core.unclean-path-5.yaml
@@ -1,0 +1,9 @@
+---
+name: foo
+arch: "${BUILD_ARCH}"
+version: 1.2.3
+license: MIT
+maintainer: "Foo Bar"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/./././././././././././././././././././bin/fake


### PR DESCRIPTION
Simple things:
* a empty folder
* Epoch is set
* a broken symlink
* a path longer than 256 characters
* A path with windows style seperators
* A path starting with a windows style `C:\`

File Validation tests
* a file that is included twice
* a file with a name longer than 256 characters
* a file with a space
* a file with a leading space
* a file with a newline character
* a file with null character

Path validation tests
* A src path with `..`
* A dst path with `../..`, thus escaping above /
* 5 different paths that are valid, but not sanitised
  * with `..`
  * multiple `/`
  * `/./`

They are not yet tested as part of the automated acceptance tests.

I think we need to upgrade the acceptance-test.go to allow for tests that are expected to fail.

- [ ] Allow `expect fail` tests in acceptance-test.go
- [ ] Add all tests to acceptance tests
