### PR TITLE
fix: deb multilines should have 1 space prefix

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -732,7 +732,7 @@ func writeControl(w io.Writer, data controlData) error {
 			return strings.Trim(strings.Join(strs, ", "), " ")
 		},
 		"multiline": func(strs string) string {
-			ret := strings.ReplaceAll(strs, "\n", "\n  ")
+			ret := strings.ReplaceAll(strs, "\n", "\n ")
 			return strings.Trim(ret, " \n")
 		},
 	})

--- a/deb/testdata/multiline.golden
+++ b/deb/testdata/multiline.golden
@@ -5,5 +5,5 @@ Priority: extra
 Architecture: riscv64
 Installed-Size: 0
 Description: This field is a
-  multiline field
-  that should work.
+ multiline field
+ that should work.


### PR DESCRIPTION
refs https://github.com/goreleaser/goreleaser/issues/2861