### PR TITLE
fix: vendor is not a recognized deb control field

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -688,9 +688,6 @@ Architecture: {{.Info.Arch}}
 {{- if .Info.Maintainer}}
 Maintainer: {{.Info.Maintainer}}
 {{- end }}
-{{- if .Info.Vendor}}
-Vendor: {{.Info.Vendor}}
-{{- end }}
 Installed-Size: {{.InstalledSize}}
 {{- with .Info.Replaces}}
 Replaces: {{join .}}

--- a/deb/testdata/control.golden
+++ b/deb/testdata/control.golden
@@ -4,7 +4,6 @@ Section: default
 Priority: extra
 Architecture: amd64
 Maintainer: Carlos A Becker <pkg@carlosbecker.com>
-Vendor: nope
 Installed-Size: 10
 Replaces: svn
 Provides: bzr

--- a/deb/testdata/control2.golden
+++ b/deb/testdata/control2.golden
@@ -4,7 +4,6 @@ Section: default
 Priority: extra
 Architecture: amd64
 Maintainer: Carlos A Becker <pkg@carlosbecker.com>
-Vendor: nope
 Installed-Size: 10
 Homepage: http://carlosbecker.com
 Description: Foo does things


### PR DESCRIPTION
refs #439 

lintian says:

```
W: nfpm: unknown-field nfpm_amd64.deb Vendor
```