### PR TITLE
Expand dependencies' version

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -153,6 +153,11 @@ func (c *Config) expandEnvVars() {
 	c.Info.Version = os.Expand(c.Info.Version, c.envMappingFunc)
 	c.Info.Prerelease = os.Expand(c.Info.Prerelease, c.envMappingFunc)
 	c.Info.Arch = os.Expand(c.Info.Arch, c.envMappingFunc)
+	for _, override := range c.Overrides {
+		for i, dep := range override.Depends {
+			override.Depends[i] = os.Expand(dep, c.envMappingFunc)
+		}
+	}
 
 	// Vendor field
 	c.Info.Vendor = os.Expand(c.Info.Vendor, c.envMappingFunc)

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -301,6 +301,25 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, packager, info.RPM.Packager)
 	})
+
+	t.Run("depends", func(t *testing.T) {
+		os.Clearenv()
+		os.Setenv("VERSION", version)
+		info, err := nfpm.Parse(strings.NewReader(`---
+name: foo
+overrides:
+  deb:
+    depends:
+    - package (= ${VERSION})
+  rpm:
+    depends:
+    - package = ${VERSION}`))
+		require.NoError(t, err)
+		require.Len(t, info.Overrides["deb"].Depends, 1)
+		require.Equal(t, "package (= 1.0.0)", info.Overrides["deb"].Depends[0])
+		require.Len(t, info.Overrides["rpm"].Depends, 1)
+		require.Equal(t, "package = 1.0.0", info.Overrides["rpm"].Depends[0])
+	})
 }
 
 func TestOverrides(t *testing.T) {


### PR DESCRIPTION
Now the version is expanded in version, but in case, when many packages are built and depend on near one with the same version it doesn't work.