### PR TITLE
feat: sign our packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - if: success()
+        name: create-keys
+        run: |
+          echo ${{ secrets.APK_SSH_KEY }} > carlos@becker.software-62072141.rsa
+          echo ${{ secrets.GPG_KEY }} > key.asc
       - uses: goreleaser/goreleaser-action@v2
         if: success()
         with:
@@ -138,3 +143,5 @@ jobs:
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
+          NFPM_DEFAULT_DEB_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
+          NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ completions/
 .task/
 cosign.*
 manpages
+key.asc
+carlos@becker.software-62072141.rsa*

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ completions/
 .task/
 cosign.*
 manpages
-key.asc
+key.gpg
 carlos@becker.software-62072141.rsa*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -139,6 +139,15 @@ nfpms:
   - rpm
   bindir: /usr/bin
   section: utils
+  rpm:
+    signature:
+      key_file: ./key.asc
+  deb:
+    signature:
+      key_file: ./key.asc
+  apk:
+    signature:
+      key_file: ./carlos@becker.software-62072141.rsa
   contents:
     - src: ./completions/nfpm.bash
       dst: /usr/share/bash-completion/completions/nfpm

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -141,10 +141,10 @@ nfpms:
   section: utils
   rpm:
     signature:
-      key_file: ./key.asc
+      key_file: ./key.gpg
   deb:
     signature:
-      key_file: ./key.asc
+      key_file: ./key.gpg
   apk:
     signature:
       key_file: ./carlos@becker.software-62072141.rsa


### PR DESCRIPTION
this should sign our packages.

apk signing is kind of useless, as it will still complain that the package signature is untrusted, even if you put the public key in `/etc/apk/keys`. 

I think it expects you to create your own apk repository (`APKINDEX.tgz`) and sign these as well. Maybe I'm wrong though, happy to hear your opinions.

If this is acceptable, I'll push the public keys to our `.github` repository, and update the docs. Will use the same keys for goreleaser itself.