### PR TITLE
feat: replace compress/gzip by klauspost/pgzip

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -29,7 +29,6 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
-	"compress/gzip"
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
@@ -49,6 +48,7 @@ import (
 	"github.com/goreleaser/nfpm/v2"
 	"github.com/goreleaser/nfpm/v2/files"
 	"github.com/goreleaser/nfpm/v2/internal/sign"
+	gzip "github.com/klauspost/pgzip"
 )
 
 const packagerName = "apk"

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -4,7 +4,6 @@ package deb
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"crypto/md5" // nolint:gas
 	"errors"
 	"fmt"
@@ -22,6 +21,7 @@ import (
 	"github.com/goreleaser/nfpm/v2/deprecation"
 	"github.com/goreleaser/nfpm/v2/files"
 	"github.com/goreleaser/nfpm/v2/internal/sign"
+	gzip "github.com/klauspost/pgzip"
 	"github.com/ulikunitz/xz"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/goreleaser/chglog v0.1.2
 	github.com/goreleaser/fileglob v1.3.0
 	github.com/imdario/mergo v0.3.12
+	github.com/klauspost/pgzip v1.2.5
 	github.com/muesli/coral v1.0.0
 	github.com/muesli/mango-coral v1.0.1
 	github.com/muesli/roff v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ github.com/klauspost/compress v1.11.7 h1:0hzRabrMN4tSTvMfnL3SCv1ZGeAP23ynzodBgaH
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
+github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=


### PR DESCRIPTION
Here's the difference between compress/gzip and https://github.com/klauspost/pgzip binary on 16 cores laptop

```
Feb 12 19:15:42 + nfpm package --target /output --config clickhouse-common-static.yaml --packager deb
Feb 12 19:15:42 using deb packager...
Feb 12 19:17:15 created package: /output/clickhouse-common-static_22.2.1.1638_amd64.deb
93 seconds

Feb 12 19:34:00 + ./nfpm package --target /output --config clickhouse-common-static.yaml --packager deb
Feb 12 19:34:00 using deb packager...
Feb 12 19:34:13 created package: /output/clickhouse-common-static_22.2.1.1638_amd64.deb
13 seconds
```

The resulting deb package is 1015M.

I am leaving a standard `compress/gzip` in tests to have a reference.