### PR TITLE
feat: add support for additional fields in Debian control files

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -718,6 +718,11 @@ Homepage: {{.Info.Homepage}}
 {{- end }}
 {{- /* Mandatory fields */}}
 Description: {{multiline .Info.Description}}
+{{- range $key, $value := .Info.Deb.Fields }}
+{{- if $value }}
+{{$key}}: {{$value}}
+{{- end }}
+{{- end }}
 `
 
 type controlData struct {

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -1267,3 +1267,34 @@ func TestArches(t *testing.T) {
 		require.Equal(t, "foo64", info.Arch)
 	})
 }
+
+func TestFields(t *testing.T) {
+	var w bytes.Buffer
+	require.NoError(t, writeControl(&w, controlData{
+		Info: nfpm.WithDefaults(&nfpm.Info{
+			Name:        "foo",
+			Description: "Foo does things",
+			Priority:    "extra",
+			Maintainer:  "Carlos A Becker <pkg@carlosbecker.com>",
+			Version:     "v1.0.0",
+			Section:     "default",
+			Homepage:    "http://carlosbecker.com",
+			Overridables: nfpm.Overridables{
+				Deb: nfpm.Deb{
+					Fields: map[string]string{
+						"Bugs":  "https://github.com/goreleaser/nfpm/issues",
+						"Empty": "",
+					},
+				},
+			},
+		}),
+		InstalledSize: 10,
+	}))
+	golden := "testdata/control3.golden"
+	if *update {
+		require.NoError(t, ioutil.WriteFile(golden, w.Bytes(), 0o600))
+	}
+	bts, err := ioutil.ReadFile(golden) //nolint:gosec
+	require.NoError(t, err)
+	require.Equal(t, string(bts), w.String())
+}

--- a/deb/testdata/control3.golden
+++ b/deb/testdata/control3.golden
@@ -1,0 +1,10 @@
+Package: foo
+Version: 1.0.0
+Section: default
+Priority: extra
+Architecture: amd64
+Maintainer: Carlos A Becker <pkg@carlosbecker.com>
+Installed-Size: 10
+Homepage: http://carlosbecker.com
+Description: Foo does things
+Bugs: https://github.com/goreleaser/nfpm/issues

--- a/nfpm.go
+++ b/nfpm.go
@@ -321,12 +321,13 @@ type APKScripts struct {
 
 // Deb is custom configs that are only available on deb packages.
 type Deb struct {
-	Arch        string       `yaml:"arch,omitempty" jsonschema:"title=architecture in deb nomenclature"`
-	Scripts     DebScripts   `yaml:"scripts,omitempty" jsonschema:"title=scripts"`
-	Triggers    DebTriggers  `yaml:"triggers,omitempty" jsonschema:"title=triggers"`
-	Breaks      []string     `yaml:"breaks,omitempty" jsonschema:"title=breaks"`
-	Signature   DebSignature `yaml:"signature,omitempty" jsonschema:"title=signature"`
-	Compression string       `yaml:"compression,omitempty" jsonschema:"title=compression algorithm to be used,enum=gzip,enum=xz,enum=none,default=gzip"`
+	Arch        string            `yaml:"arch,omitempty" jsonschema:"title=architecture in deb nomenclature"`
+	Scripts     DebScripts        `yaml:"scripts,omitempty" jsonschema:"title=scripts"`
+	Triggers    DebTriggers       `yaml:"triggers,omitempty" jsonschema:"title=triggers"`
+	Breaks      []string          `yaml:"breaks,omitempty" jsonschema:"title=breaks"`
+	Signature   DebSignature      `yaml:"signature,omitempty" jsonschema:"title=signature"`
+	Compression string            `yaml:"compression,omitempty" jsonschema:"title=compression algorithm to be used,enum=gzip,enum=xz,enum=none,default=gzip"`
+	Fields      map[string]string `yaml:"fields,omitempty" jsonschema:"title=fields"`
 }
 
 type DebSignature struct {

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -305,6 +305,10 @@ deb:
     # This will expand any env var you set in the field, eg key_id: ${DEB_SIGNING_KEY_ID}
     key_id: bc8acdd415bd80b3
 
+  # Additional fields for the control file. Empty fields are ignored.
+  fields:
+    Bugs: https://github.com/goreleaser/nfpm/issues
+
 apk:
   # apk specific architecture name that overrides "arch" without performing any replacements.
   apk_arch: armhf


### PR DESCRIPTION
Debian control files (DCF) have [a number of optional fields](https://man7.org/linux/man-pages/man5/deb-control.5.html) -- including "Bugs" and "Tags" -- that are used by many existing packages. The original `fpm` supports adding arbitrary fields to DCFs [with the `--deb-field` flag](https://fpm.readthedocs.io/en/latest/packages/deb.html?highlight=changelog#deb-specific-command-line-flags), but until now it was not possible to do so with `nfpm`.

This PR introduces a new deb-specific override, `fields`, that simply translates key-value pairs from a map directly into the DCF.
Given the following `nfpm` config file entry:

    deb:
      fields:
        Bugs: https://github.com/goreleaser/nfpm/issues

The resulting DCF would contain the entry

    Bugs: https://github.com/goreleaser/nfpm/issues

To avoid generating malformed DCFs, we simply ignore empty entries.

This PR includes unit tests and updates to the website documentation.

Closes #490.