### PR TITLE
fix: deb version order in control

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -681,9 +681,9 @@ const controlTemplate = `
 {{- /* Mandatory fields */ -}}
 Package: {{.Info.Name}}
 Version: {{ if .Info.Epoch}}{{ .Info.Epoch }}:{{ end }}{{.Info.Version}}
-         {{- if .Info.Release}}-{{ .Info.Release }}{{- end }}
          {{- if .Info.Prerelease}}~{{ .Info.Prerelease }}{{- end }}
          {{- if .Info.VersionMetadata}}+{{ .Info.VersionMetadata }}{{- end }}
+         {{- if .Info.Release}}-{{ .Info.Release }}{{- end }}
 Section: {{.Info.Section}}
 Priority: {{.Info.Priority}}
 Architecture: {{.Info.Arch}}

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -157,7 +157,7 @@ func TestDebVersionWithReleaseAndPrerelease(t *testing.T) {
 	err := writeControl(&buf, controlData{info, 0})
 	require.NoError(t, err)
 	v := extractDebVersion(&buf)
-	require.Equal(t, "1.0.0-2~rc1", v)
+	require.Equal(t, "1.0.0~rc1-2", v)
 }
 
 func TestDebVersionWithVersionMetadata(t *testing.T) {
@@ -252,6 +252,41 @@ func TestNoJoinsControl(t *testing.T) {
 		InstalledSize: 10,
 	}))
 	golden := "testdata/control2.golden"
+	if *update {
+		require.NoError(t, ioutil.WriteFile(golden, w.Bytes(), 0o600))
+	}
+	bts, err := ioutil.ReadFile(golden) //nolint:gosec
+	require.NoError(t, err)
+	require.Equal(t, string(bts), w.String())
+}
+
+func TestVersionControl(t *testing.T) {
+	var w bytes.Buffer
+	require.NoError(t, writeControl(&w, controlData{
+		Info: nfpm.WithDefaults(&nfpm.Info{
+			Name:        "foo",
+			Arch:        "amd64",
+			Description: "Foo does things",
+			Priority:    "extra",
+			Maintainer:  "Carlos A Becker <pkg@carlosbecker.com>",
+			Version:     "v1.0.0-beta+meta",
+			Release:     "2",
+			Section:     "default",
+			Homepage:    "http://carlosbecker.com",
+			Vendor:      "nope",
+			Overridables: nfpm.Overridables{
+				Depends:    []string{},
+				Recommends: []string{},
+				Suggests:   []string{},
+				Replaces:   []string{},
+				Provides:   []string{},
+				Conflicts:  []string{},
+				Contents:   []*files.Content{},
+			},
+		}),
+		InstalledSize: 10,
+	}))
+	golden := "testdata/control4.golden"
 	if *update {
 		require.NoError(t, ioutil.WriteFile(golden, w.Bytes(), 0o600))
 	}

--- a/deb/testdata/control4.golden
+++ b/deb/testdata/control4.golden
@@ -1,0 +1,9 @@
+Package: foo
+Version: 1.0.0~beta+meta-2
+Section: default
+Priority: extra
+Architecture: amd64
+Maintainer: Carlos A Becker <pkg@carlosbecker.com>
+Installed-Size: 10
+Homepage: http://carlosbecker.com
+Description: Foo does things


### PR DESCRIPTION
This should have been caught in https://github.com/goreleaser/nfpm/pull/375 but I missed it.

The version string when using `Release` is correct in the filename, but incorrect in the control file.

Here's the [debian docs on the control file's version](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version)

Before:
Filename: `foo_1.2.3~pre+meta-2_amd64.deb`
control version: `1.2.3-2~pre+meta`

After:
Filename: `foo_1.2.3~pre+meta-2_amd64.deb`
control version: `1.2.3~pre+meta-2`

✅ `task ci` 🚀 