### PR TITLE
feat: implement dpkg-sig Package signing

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -219,7 +219,7 @@ func newDpkgSigFileLine(name string, fileContent []byte) dpkgSigFileLine {
 	}
 }
 
-func readDpkgSigData(info *nfpm.Info, debianBinary, controlTarGz, dataTarball []byte) io.Reader {
+func readDpkgSigData(info *nfpm.Info, debianBinary, controlTarGz, dataTarball []byte) (io.Reader, error) {
 	data := dpkgSigData{
 		Files: []dpkgSigFileLine{
 			newDpkgSigFileLine("debian-binary", debianBinary),
@@ -229,8 +229,11 @@ func readDpkgSigData(info *nfpm.Info, debianBinary, controlTarGz, dataTarball []
 	}
 	temp, _ := template.New("dpkg-sig").Parse(dpkgSigTemplate)
 	buf := &bytes.Buffer{}
-	temp.Execute(buf, data)
-	return buf
+	err := temp.Execute(buf, data)
+	if err != nil {
+		return nil, fmt.Errorf("dpkg-sig template error: %w", err)
+	}
+	return buf, nil
 }
 
 func (*Deb) SetPackagerDefaults(info *nfpm.Info) {

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -196,7 +196,7 @@ Signer: {{ .Signer }}
 Date: {{ .Date }}
 Role: {{ .Role }}
 Files:
-{{range .Files}}{{ .File.md5sum }} {{ .File.sha1sum }} {{ .File.size }} {{ .File.name }}{{end}}
+{{range .Files}}{{ .md5sum }} {{ .File.sha1sum }} {{ .File.size }} {{ .File.name }}{{end}}
 `
 
 type dpkgSigData struct {

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -196,7 +196,7 @@ Signer: {{ .Signer }}
 Date: {{ .Date }}
 Role: {{ .Role }}
 Files:
-{{range .Files}}{{ .md5sum }} {{ .File.sha1sum }} {{ .File.size }} {{ .File.name }}{{end}}
+{{range .Files}}{{ .md5sum }} {{ .sha1sum }} {{ .size }} {{ .name }}{{end}}
 `
 
 type dpkgSigData struct {

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -951,6 +951,7 @@ func TestDpkgSigSignature(t *testing.T) {
 	info.Deb.Signature.KeyFile = "../internal/sign/testdata/privkey.asc"
 	info.Deb.Signature.KeyPassphrase = "hunter2"
 	info.Deb.Signature.Method = "dpkg-sig"
+	info.Deb.Signature.Signer = "bob McRobert"
 
 	var deb bytes.Buffer
 	err := Default.Package(info, &deb)

--- a/nfpm.go
+++ b/nfpm.go
@@ -335,7 +335,8 @@ type DebSignature struct {
 	// debsign, or dpkg-sig (defaults to debsign)
 	Method string `yaml:"method,omitempty" jsonschema:"title=method role,enum=debsign,enum=dpkg-sig,default=debsign"`
 	// origin, maint or archive (defaults to origin)
-	Type string `yaml:"type,omitempty" jsonschema:"title=signer role,enum=origin,enum=maint,enum=archive,default=origin"`
+	Type   string `yaml:"type,omitempty" jsonschema:"title=signer role,enum=origin,enum=maint,enum=archive,default=origin"`
+	Signer string `yaml:"signer,omitempty" jsonschema:"title=signer"`
 }
 
 // DebTriggers contains triggers only available for deb packages.

--- a/nfpm.go
+++ b/nfpm.go
@@ -332,6 +332,8 @@ type Deb struct {
 
 type DebSignature struct {
 	PackageSignature `yaml:",inline"`
+	// debsign, or dpkg-sig (defaults to debsign)
+	Method string `yaml:"method,omitempty" jsonschema:"title=method role,enum=debsign,enum=dpkg-sig,default=debsign"`
 	// origin, maint or archive (defaults to origin)
 	Type string `yaml:"type,omitempty" jsonschema:"title=signer role,enum=origin,enum=maint,enum=archive,default=origin"`
 }


### PR DESCRIPTION
As mentioned [here](https://github.com/goreleaser/nfpm/issues/212) Debsign package verification is a PITA.

Herewith my proposal to implement dpkg-sig style package verification.
As mentioned in the original thread, debsign and dpkg-sig are mutually exclusive, but it would be nice to be able to choose between them.