### PR TITLE
Fix apk versioning

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -90,16 +90,13 @@ type Apk struct{}
 func (a *Apk) ConventionalFileName(info *nfpm.Info) string {
 	info = ensureValidArch(info)
 	version := info.Version
-	if info.Release != "" {
-		version += "-" + info.Release
-	}
 
 	if info.Prerelease != "" {
-		version += "~" + info.Prerelease
+		version += "" + info.Prerelease
 	}
 
-	if info.VersionMetadata != "" {
-		version += "+" + info.VersionMetadata
+	if info.Release != "" {
+		version += "-" + info.Release
 	}
 
 	return fmt.Sprintf("%s_%s_%s.apk", info.Name, version, info.Arch)
@@ -559,10 +556,9 @@ func pathsToCreate(dst string) []string {
 const controlTemplate = `
 {{- /* Mandatory fields */ -}}
 pkgname = {{.Info.Name}}
-pkgver = {{ if .Info.Epoch}}{{ .Info.Epoch }}:{{ end }}{{.Info.Version}}
+pkgver = {{.Info.Version}}
+		 {{- if .Info.Prerelease}}{{ .Info.Prerelease }}{{- end }}
          {{- if .Info.Release}}-{{ .Info.Release }}{{- end }}
-         {{- if .Info.Prerelease}}~{{ .Info.Prerelease }}{{- end }}
-         {{- if .Info.VersionMetadata}}+{{ .Info.VersionMetadata }}{{- end }}
 arch = {{.Info.Arch}}
 size = {{.InstalledSize}}
 pkgdesc = {{multiline .Info.Description}}

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -32,6 +32,7 @@ func exampleInfo() *nfpm.Info {
 		Priority:    "extra",
 		Maintainer:  "Carlos A Becker <pkg@carlosbecker.com>",
 		Version:     "v1.0.0",
+		Prerelease:  "beta1",
 		Release:     "r1",
 		Section:     "default",
 		Homepage:    "http://carlosbecker.com",
@@ -444,20 +445,20 @@ func TestAPKConventionalFileName(t *testing.T) {
 			Expect: "default_1.2.3_x86_64.apk",
 		},
 		{
-			Arch: "386", Version: "1.2.3", Meta: "git",
-			Expect: "default_1.2.3+git_x86.apk",
+			Arch: "386", Version: "1.2.3", Prerelease: "git",
+			Expect: "default_1.2.3git_x86.apk",
 		},
 		{
-			Arch: "386", Version: "1.2.3", Meta: "git", Release: "1",
-			Expect: "default_1.2.3-1+git_x86.apk",
+			Arch: "386", Version: "1.2.3", Prerelease: "git", Release: "1",
+			Expect: "default_1.2.3git-1_x86.apk",
 		},
 		{
 			Arch: "all", Version: "1.2.3",
 			Expect: "default_1.2.3_all.apk",
 		},
 		{
-			Arch: "386", Version: "1.2.3", Release: "1", Prerelease: "5",
-			Expect: "default_1.2.3-1~5_x86.apk",
+			Arch: "386", Version: "1.2.3", Release: "1", Prerelease: "beta",
+			Expect: "default_1.2.3beta-1_x86.apk",
 		},
 	}
 

--- a/apk/testdata/TestControl.golden
+++ b/apk/testdata/TestControl.golden
@@ -1,5 +1,5 @@
 pkgname = foo
-pkgver = 1.0.0-r1
+pkgver = 1.0.0beta1-r1
 arch = amd64
 size = 10
 pkgdesc = Foo does things

--- a/apk/testdata/TestCreateBuilderControl.golden
+++ b/apk/testdata/TestCreateBuilderControl.golden
@@ -1,5 +1,5 @@
 pkgname = foo
-pkgver = 1.0.0-r1
+pkgver = 1.0.0beta1-r1
 arch = amd64
 size = 12345
 pkgdesc = Foo does things

--- a/apk/testdata/TestCreateBuilderControlScripts.golden
+++ b/apk/testdata/TestCreateBuilderControlScripts.golden
@@ -1,5 +1,5 @@
 pkgname = foo
-pkgver = 1.0.0-r1
+pkgver = 1.0.0beta1-r1
 arch = amd64
 size = 12345
 pkgdesc = Foo does things


### PR DESCRIPTION
Fixes https://github.com/goreleaser/nfpm/issues/474

Following examples from https://wiki.gentoo.org/wiki/Version_specifier as well as https://wiki.alpinelinux.org/wiki/APKBUILD_Reference#pkgver

I used `Info.Prerelease` as the `pkgver.suf` as described above, since that maps most similarly to the semver prerelease field. It potentially has some overlap with `Info.VersionMetadata` though. For parity with these fields for other package types in nfpm, it would maybe make sense to append both Prerelease and VersionMetadata to the version, however we would have to ensure that only one of the two fields is used.

Maybe it's better to expect the user to put  `{letter}` and `{suf{#}}` in `Info.Version` instead.