### PR TITLE
chore: improving ci config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,20 +6,37 @@ on:
       - v*
     branches:
       - main
+    paths:
+      - 'go.*'
+      - '**/*.go'
+      - 'Taskfile.yml'
+      - 'Dockerfile'
+      - '.github/workflows/build.yml'
+      - 'testdata/'
   pull_request:
+    paths:
+      - 'go.*'
+      - '**/*.go'
+      - 'Taskfile.yml'
+      - 'Dockerfile'
+      - '.github/workflows/build.yml'
+      - 'testdata/'
 
 permissions:
-  contents: write
-  id-token: write
-  packages: write
+  contents: read
 
 jobs:
   govulncheck:
     uses: caarlos0/meta/.github/workflows/govulncheck.yml@main
+    with:
+      go-version: '>=1.19.1'
   semgrep:
     uses: caarlos0/meta/.github/workflows/semgrep.yml@main
   ruleguard:
     uses: caarlos0/meta/.github/workflows/ruleguard.yml@main
+    with:
+      go-version: '>=1.19.1'
+      args: '-disable largeloopcopy'
   unit-tests:
     strategy:
       matrix:
@@ -27,11 +44,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.19'
+          go-version: '>=1.19.1'
           cache: true
       - uses: arduino/setup-task@v1
         with:
@@ -59,7 +74,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.19'
+          go-version: '>=1.19.1'
           cache: true
       - uses: arduino/setup-task@v1
         with:
@@ -73,58 +88,4 @@ jobs:
         run: ./scripts/test.sh acceptance ubuntu-latest
         env:
           TEST_PATTERN: "/${{ matrix.pkgFormat }}/${{ matrix.pkgPlatform }}/"
-  goreleaser:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
-    needs:
-      - unit-tests
-      - Acceptance-Tests
-    permissions:
-      contents: write
-      id-token: write
-      packages: write
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '~1.19'
-          cache: true
-      - uses: arduino/setup-task@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: sigstore/cosign-installer@v2.6.0
-      - uses: anchore/sbom-action/download-syft@v0.12.0
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - run: task setup
-      - run: task build
-      - uses: docker/login-action@v2
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - uses: docker/login-action@v2
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: goreleaser/goreleaser-action@v3
-        if: success()
-        with:
-          version: latest
-          args: release --rm-dist
-          distribution: goreleaser-pro
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
-          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
-          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-          DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
-          DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
-          AUR_KEY: ${{ secrets.AUR_KEY }}
+

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   analyze:
-    name: analyze
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ permissions: read-all
 
 jobs:
   htmltest:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -22,6 +23,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
+          cache: true
       - run: task docs:build
       - uses: wjdp/htmltest-action@master
         with:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,23 +13,17 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      -
-        name: checkout
-        uses: actions/checkout@v3
-      -
-        name: setup go
-        uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
-      -
-        name: Set up Task
-        uses: arduino/setup-task@v1
+          go-version: '>=1.19.1'
+          cache: true
+      - uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Refresh docs
-        run: task docs:generate
+      - run: task docs:generate
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "docs: update cmd docs"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ~1.19
-      - uses: actions/checkout@v3
+          go-version: '>=1.19.1'
+          cache: true
       - uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   lock:
-    if: github.repository == 'goreleaser/nfpm'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   milestone:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.1'
+          cache: true
+      - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: sigstore/cosign-installer@v2.6.0
+      - uses: anchore/sbom-action/download-syft@v0.12.0
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - run: task setup
+      - run: task build
+      - uses: docker/login-action@v2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/login-action@v2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: goreleaser/goreleaser-action@v3
+        if: success()
+        with:
+          version: latest
+          args: release --rm-dist
+          distribution: goreleaser-pro
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+          AUR_KEY: ${{ secrets.AUR_KEY }}


### PR DESCRIPTION
- split release into another workflow - we only release after some time anyway, so tests already passed on main, no need to wait for them again
- minor improvements et al on the other workflows as well
- forcing go >=1.19.1