### PR TITLE
fix: a few improvements related to deb changelogs

### DIFF
--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -539,43 +539,6 @@ func TestDEBConventionalFileName(t *testing.T) {
 	}
 }
 
-func TestDebChangelogControl(t *testing.T) {
-	info := &nfpm.Info{
-		Name:        "changelog-test",
-		Arch:        "amd64",
-		Description: "This package has changelogs.",
-		Version:     "1.0.0",
-		Changelog:   "../testdata/changelog.yaml",
-	}
-	err := info.Validate()
-	require.NoError(t, err)
-
-	controlTarGz, err := createControl(0, []byte{}, info)
-	require.NoError(t, err)
-
-	controlChangelog := extractFileFromTar(t, inflate(t, "gz", controlTarGz), "changelog")
-
-	goldenChangelog := readAndFormatAsDebChangelog(t, info.Changelog, info.Name)
-
-	require.Equal(t, goldenChangelog, string(controlChangelog))
-}
-
-func TestDebNoChangelogControlWithoutChangelogConfigured(t *testing.T) {
-	info := &nfpm.Info{
-		Name:        "no-changelog-test",
-		Arch:        "amd64",
-		Description: "This package has explicitly no changelog.",
-		Version:     "1.0.0",
-	}
-	err := info.Validate()
-	require.NoError(t, err)
-
-	controlTarGz, err := createControl(0, []byte{}, info)
-	require.NoError(t, err)
-
-	require.False(t, tarContains(t, inflate(t, "gz", controlTarGz), "changelog"))
-}
-
 func TestDebChangelogData(t *testing.T) {
 	info := &nfpm.Info{
 		Name:        "changelog-test",
@@ -590,7 +553,7 @@ func TestDebChangelogData(t *testing.T) {
 	dataTarball, _, _, dataTarballName, err := createDataTarball(info)
 	require.NoError(t, err)
 
-	changelogName := fmt.Sprintf("/usr/share/doc/%s/changelog.gz", info.Name)
+	changelogName := fmt.Sprintf("/usr/share/doc/%s/changelog.Debian.gz", info.Name)
 	dataChangelogGz := extractFileFromTar(t,
 		inflate(t, dataTarballName, dataTarball), changelogName)
 

--- a/testdata/acceptance/deb.dockerfile
+++ b/testdata/acceptance/deb.dockerfile
@@ -125,12 +125,19 @@ FROM test_base AS withchangelog
 # image filters out changelogs by default
 # so we have to remove that rule
 RUN apt update -y
-RUN apt install -y gzip
+RUN apt install -y gzip lintian
 RUN dpkg -i /tmp/foo.deb
-RUN zcat "/usr/share/doc/foo/changelog.gz" | grep "Carlos A Becker <pkg@carlosbecker.com>"
-RUN zcat "/usr/share/doc/foo/changelog.gz" | grep "note 1"
-RUN zcat "/usr/share/doc/foo/changelog.gz" | grep "note 2"
-RUN zcat "/usr/share/doc/foo/changelog.gz" | grep "note 3"
+RUN zcat "/usr/share/doc/foo/changelog.Debian.gz" | grep "Carlos A Becker <pkg@carlosbecker.com>"
+RUN zcat "/usr/share/doc/foo/changelog.Debian.gz" | grep "note 1"
+RUN zcat "/usr/share/doc/foo/changelog.Debian.gz" | grep "note 2"
+RUN zcat "/usr/share/doc/foo/changelog.Debian.gz" | grep "note 3"
+RUN lintian /tmp/foo.deb > lintian.out
+RUN test "$(grep -- 'debian-changelog-file-missing-or-wrong-name' lintian.out)" = ""
+RUN test "$(grep -- 'changelog-not-compressed-with-max-compression' lintian.out)" = ""
+RUN test "$(grep -- 'unknown-control-file changelog' lintian.out)" = ""
+# TODO:
+# RUN test "$(grep -- 'package-contains-timestamped-gzip' lintian.out)" = ""
+# RUN test "$(grep -- 'syntax-error-in-debian-changelog' lintian.out)" = ""
 
 # ---- rules test ----
 FROM min AS rules


### PR DESCRIPTION
In particular, this change fixes the following errors/warnings reported by lintian(1):

E: debian-changelog-file-missing-or-wrong-name
https://lintian.debian.org/tags/debian-changelog-file-missing-or-wrong-name

W: changelog-not-compressed-with-max-compression usr/share/doc/foo/changelog.gz https://lintian.debian.org/tags/changelog-not-compressed-with-max-compression

W: unknown-control-file changelog
https://lintian.debian.org/tags/unknown-control-file

Tests were adjusted accordingly.