### PR TITLE
Add Prefix option to create relocatable packages.

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -244,8 +244,9 @@ type Info struct {
 	Homepage        string `yaml:"homepage,omitempty" json:"homepage,omitempty" jsonschema:"title=package homepage,example=https://example.com"`
 	License         string `yaml:"license,omitempty" json:"license,omitempty" jsonschema:"title=package license,example=MIT"`
 	Changelog       string `yaml:"changelog,omitempty" json:"changelog,omitempty" jsonschema:"title=package changelog,example=changelog.yaml,description=see https://github.com/goreleaser/chglog for more details"`
-	DisableGlobbing bool   `yaml:"disable_globbing,omitempty" json:"disable_globbing,omitempty" jsonschema:"title=wether to disable file globbing,default=false"`
+	DisableGlobbing bool   `yaml:"disable_globbing,omitempty" json:"disable_globbing,omitempty" jsonschema:"title=whether to disable file globbing,default=false"`
 	Target          string `yaml:"-" json:"-"`
+	Prefix          string `yaml:"prefix,omitempty" json:"prefix,omitempty" jsonschema:"title=Prefix for relocatable packages,example=/opt/homebrew"`
 }
 
 func (i *Info) Validate() error {

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -2,6 +2,7 @@ package nfpm_test
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"net/mail"
 	"os"
@@ -363,6 +364,18 @@ overrides:
 		require.Equal(t, "package (= 1.0.0)", info.Overrides["deb"].Depends[0])
 		require.Len(t, info.Overrides["rpm"].Depends, 1)
 		require.Equal(t, "package = 1.0.0", info.Overrides["rpm"].Depends[0])
+	})
+
+	t.Run("prefix-is-allowed", func(t *testing.T) {
+		os.Clearenv()
+		require.NoError(t, os.Setenv("VERSION", version))
+		require.NoError(t, os.Setenv("PKG", ""))
+		info, err := nfpm.Parse(strings.NewReader(`---
+name: foo
+prefix: /opt/homebrew
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "/opt/homebrew", info.Prefix)
 	})
 }
 

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -25,6 +25,8 @@ const (
 	tagChangelogName = 1081
 	// https://github.com/rpm-software-management/rpm/blob/master/lib/rpmtag.h#L154
 	tagChangelogText = 1082
+	// http://ftp.rpm.org/api/4.12.0.1/rpmtag_8h.html
+	tagPrefixes = 1098
 
 	// Symbolic link
 	tagLink = 0o120000
@@ -134,11 +136,19 @@ func (*RPM) Package(info *nfpm.Info, w io.Writer) (err error) {
 		}
 	}
 
+	if info.Prefix != "" {
+		addPrefix(info, rpm)
+	}
+
 	if err = rpm.Write(w); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func addPrefix(info *nfpm.Info, rpm *rpmpack.RPM) {
+	rpm.AddCustomTag(tagPrefixes, rpmpack.EntryString(info.Prefix))
 }
 
 func addChangeLog(info *nfpm.Info, rpm *rpmpack.RPM) error {


### PR DESCRIPTION
In order to create "relocatable" packages, one may provide the Prefix tag, which marks the part to be stripped off when relocating.

- See https://ftp.osuosl.org/pub/rpm/max-rpm/s1-rpm-inside-tags.html#S3-RPM-INSIDE-PREFIX-TAG

