### PR TITLE
fix: do not encourage using /usr/local/bin

### DIFF
--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -65,7 +65,7 @@ func exampleInfo() *nfpm.Info {
 			Contents: []*files.Content{
 				{
 					Source:      "../testdata/fake",
-					Destination: "/usr/local/bin/fake",
+					Destination: "/usr/bin/fake",
 				},
 				{
 					Source:      "../testdata/whatever.conf",
@@ -110,7 +110,7 @@ func TestCreateBuilderData(t *testing.T) {
 
 	require.NoError(t, builderData(tw))
 
-	require.Equal(t, 13832, buf.Len())
+	require.Equal(t, 13320, buf.Len())
 }
 
 func TestCombineToApk(t *testing.T) {
@@ -143,7 +143,7 @@ func TestPathsToCreate(t *testing.T) {
 func TestDefaultWithArch(t *testing.T) {
 	expectedChecksums := map[string]string{
 		"usr/share/doc/fake/fake.txt": "96c335dc28122b5f09a4cef74b156cd24c23784c",
-		"usr/local/bin/fake":          "f46cece3eeb7d9ed5cb244d902775427be71492d",
+		"usr/bin/fake":                "f46cece3eeb7d9ed5cb244d902775427be71492d",
 		"etc/fake/fake.conf":          "96c335dc28122b5f09a4cef74b156cd24c23784c",
 		"etc/fake/fake2.conf":         "96c335dc28122b5f09a4cef74b156cd24c23784c",
 	}
@@ -200,7 +200,7 @@ func TestFileDoesNotExist(t *testing.T) {
 				Contents: []*files.Content{
 					{
 						Source:      "../testdata/fake",
-						Destination: "/usr/local/bin/fake",
+						Destination: "/usr/bin/fake",
 					},
 					{
 						Source:      "../testdata/whatever.confzzz",

--- a/arch/arch_test.go
+++ b/arch/arch_test.go
@@ -42,7 +42,7 @@ func exampleInfo() *nfpm.Info {
 			Contents: []*files.Content{
 				{
 					Source:      "../testdata/fake",
-					Destination: "/usr/local/bin/fake",
+					Destination: "/usr/share/bin/fake",
 				},
 				{
 					Source:      "../testdata/whatever.conf",

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -62,7 +62,7 @@ func exampleInfo() *nfpm.Info {
 			Contents: []*files.Content{
 				{
 					Source:      "../testdata/fake",
-					Destination: "/usr/local/bin/fake",
+					Destination: "/usr/bin/fake",
 				},
 				{
 					Source:      "../testdata/whatever.conf",
@@ -325,7 +325,7 @@ func TestDebFileDoesNotExist(t *testing.T) {
 				Contents: []*files.Content{
 					{
 						Source:      "../testdata/fake",
-						Destination: "/usr/local/bin/fake",
+						Destination: "/usr/bin/fake",
 					},
 					{
 						Source:      "../testdata/whatever.confzzz",

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -69,13 +69,13 @@ license: "MIT"
 changelog: "changelog.yaml"
 contents:
 - src: ./foo
-  dst: /usr/local/bin/foo
+  dst: /usr/bin/foo
 - src: ./bar
-  dst: /usr/local/bin/bar
+  dst: /usr/bin/bar
 - src: ./foobar.conf
   dst: /etc/foobar.conf
   type: config
-- src: /usr/local/bin/foo
+- src: /usr/bin/foo
   dst: /sbin/foo
   type: symlink
 overrides:

--- a/internal/rpmpack/rpm_test.go
+++ b/internal/rpmpack/rpm_test.go
@@ -22,7 +22,7 @@ func TestFileOwner(t *testing.T) {
 	user := "testUser"
 
 	r.AddFile(RPMFile{
-		Name:  "/usr/local/hello",
+		Name:  "/usr/hello",
 		Body:  []byte("content of the file"),
 		Group: group,
 		Owner: user,
@@ -46,7 +46,7 @@ func Test100644(t *testing.T) {
 		t.Fatalf("NewRPM returned error %v", err)
 	}
 	r.AddFile(RPMFile{
-		Name: "/usr/local/hello",
+		Name: "/usr/share/hello",
 		Body: []byte("content of the file"),
 		Mode: 0o100644,
 	})
@@ -162,20 +162,20 @@ func TestAllowListDirs(t *testing.T) {
 	}
 
 	r.AddFile(RPMFile{
-		Name: "/usr/local/dir1",
+		Name: "/usr/share/dir1",
 		Mode: 0o40000,
 	})
 	r.AddFile(RPMFile{
-		Name: "/usr/local/dir2",
+		Name: "/usr/share/dir2",
 		Mode: 0o40000,
 	})
 
-	r.AllowListDirs(map[string]bool{"/usr/local/dir1": true})
+	r.AllowListDirs(map[string]bool{"/usr/share/dir1": true})
 
 	if err := r.Write(io.Discard); err != nil {
 		t.Errorf("NewRPM returned error %v", err)
 	}
-	expected := map[string]RPMFile{"/usr/local/dir1": {Name: "/usr/local/dir1", Mode: 0o40000}}
+	expected := map[string]RPMFile{"/usr/share/dir1": {Name: "/usr/share/dir1", Mode: 0o40000}}
 	if d := cmp.Diff(expected, r.files); d != "" {
 		t.Errorf("Expected dirs differs (want->got):\n%v", d)
 	}

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -54,7 +54,7 @@ func exampleInfo() *nfpm.Info {
 			Contents: []*files.Content{
 				{
 					Source:      "../testdata/fake",
-					Destination: "/usr/local/bin/fake",
+					Destination: "/usr/bin/fake",
 				},
 				{
 					Source:      "../testdata/whatever.conf",
@@ -466,7 +466,7 @@ func TestRPMFileDoesNotExist(t *testing.T) {
 	info.Contents = []*files.Content{
 		{
 			Source:      "../testdata/fake",
-			Destination: "/usr/local/bin/fake",
+			Destination: "/usr/bin/fake",
 		},
 		{
 			Source:      "../testdata/whatever.confzzz",

--- a/testdata/acceptance/apk.dockerfile
+++ b/testdata/acceptance/apk.dockerfile
@@ -16,12 +16,12 @@ RUN ls -l /path/to/symlink | grep "/path/to/symlink -> /etc/foo/whatever.conf"
 
 # ---- simple test ----
 FROM min AS simple
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN echo wat >> /etc/foo/whatever.conf
 RUN apk del foo
 RUN test -f /etc/foo/whatever.conf
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 
 
 # ---- no-glob test ----
@@ -36,7 +36,7 @@ RUN test -f /usr/share/whatever/folder2/file2
 
 # ---- complex test ----
 FROM min AS complex
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN test -d /usr/share/whatever/
 RUN test -d /usr/share/whatever/folder
@@ -61,7 +61,7 @@ RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf
 RUN apk del foo
 RUN test -f /etc/foo/whatever.conf
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 RUN test ! -f /usr/sbin/fake
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
@@ -79,7 +79,7 @@ RUN apk add  /tmp/foo.apk
 
 # ---- overrides test ----
 FROM min AS overrides
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN test ! -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
@@ -88,7 +88,7 @@ RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf
 RUN apk del foo
 RUN test -f /etc/foo/whatever.conf
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 RUN test -f /tmp/preremove-proof
 RUN test ! -f /tmp/postremove-proof
 

--- a/testdata/acceptance/apk.dockerfile
+++ b/testdata/acceptance/apk.dockerfile
@@ -53,7 +53,7 @@ RUN test -f /etc/something/a
 RUN test -f /etc/something/b
 RUN test -d /etc/something/c
 RUN test -f /etc/something/c/d
-RUN test $(stat -c %a /usr/sbin/fake) -eq 4755
+RUN test $(stat -c %a /usr/bin/fake2) -eq 4755
 RUN test -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
 RUN test ! -f /tmp/preremove-proof
@@ -62,7 +62,7 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN apk del foo
 RUN test -f /etc/foo/whatever.conf
 RUN test ! -f /usr/bin/fake
-RUN test ! -f /usr/sbin/fake
+RUN test ! -f /usr/bin/fake2
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
 RUN test ! -d /var/log/whatever

--- a/testdata/acceptance/archlinux.dockerfile
+++ b/testdata/acceptance/archlinux.dockerfile
@@ -56,7 +56,7 @@ RUN test -f /etc/something/a
 RUN test -f /etc/something/b
 RUN test -d /etc/something/c
 RUN test -f /etc/something/c/d
-RUN test $(stat -c %a /usr/bin/fake) -eq 4755
+RUN test $(stat -c %a /usr/bin/fake2) -eq 4755
 RUN test -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
 RUN test ! -f /tmp/preremove-proof
@@ -65,7 +65,7 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN pacman --noconfirm -R foo
 RUN test -f /etc/foo/whatever.conf.pacsave
 RUN test ! -f /usr/bin/fake
-RUN test ! -f /usr/bin/fake
+RUN test ! -f /usr/bin/fake2
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
 RUN test ! -d /var/log/whatever

--- a/testdata/acceptance/archlinux.dockerfile
+++ b/testdata/acceptance/archlinux.dockerfile
@@ -16,12 +16,12 @@ RUN ls -l /path/to/symlink | grep "/path/to/symlink -> /etc/foo/whatever.conf"
 
 # ---- simple test ----
 FROM min AS simple
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN echo wat >> /etc/foo/whatever.conf
 RUN pacman --noconfirm -R foo
 RUN test -f /etc/foo/whatever.conf.pacsave
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 
 
 # ---- no-glob test ----
@@ -39,7 +39,7 @@ FROM min AS complex
 RUN pacman -Qi foo | grep "Depends On\\s*: bash"
 RUN pacman -Qi foo | grep "Replaces\\s*: foo"
 RUN pacman -Qi foo | grep "Provides\\s*: fake"
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN test -d /usr/share/whatever/
 RUN test -d /usr/share/whatever/folder
@@ -64,7 +64,7 @@ RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf
 RUN pacman --noconfirm -R foo
 RUN test -f /etc/foo/whatever.conf.pacsave
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 RUN test ! -f /usr/bin/fake
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
@@ -80,7 +80,7 @@ RUN echo "Arch Linux has no signature support"
 
 # ---- overrides test ----
 FROM min AS overrides
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN test ! -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
@@ -89,7 +89,7 @@ RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf
 RUN pacman --noconfirm -R foo
 RUN test -f /etc/foo/whatever.conf.pacsave
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 RUN test -f /tmp/preremove-proof
 RUN test ! -f /tmp/postremove-proof
 

--- a/testdata/acceptance/core.complex.yaml
+++ b/testdata/acceptance/core.complex.yaml
@@ -29,32 +29,39 @@ contents:
   type: config
 - src: ./testdata/something
   dst: /etc/something
-- src: ./testdata/fake
-  dst: /usr/sbin/fake
-  packager: deb
-  file_info:
-    mode: 04755
-- src: ./testdata/fake
-  dst: /usr/sbin/fake
-  packager: rpm
-  file_info:
-    mode: 04755
-- src: ./testdata/fake
-  dst: /usr/sbin/fake
-  packager: apk
-  file_info:
-    mode: 04755
-- src: ./testdata/fake
-  dst: /usr/bin/fake
-  file_info:
-    mode: 04755
-  packager: archlinux
 - dst: /usr/foo/bar/something
   type: dir
 - dst: /var/log/whatever
   type: dir
 - dst: /usr/share/foo
   type: dir
+
+# Packager specifics:
+
+- packager: deb
+  src: ./testdata/fake
+  dst: /usr/bin/fake2
+  file_info:
+    mode: 04755
+
+- packager: rpm
+  src: ./testdata/fake
+  dst: /usr/bin/fake2
+  file_info:
+    mode: 04755
+
+- packager: apk
+  src: ./testdata/fake
+  dst: /usr/bin/fake2
+  file_info:
+    mode: 04755
+
+- packager: archlinux
+  src: ./testdata/fake
+  dst: /usr/bin/fake2
+  file_info:
+    mode: 04755
+
 scripts:
   preinstall: ./testdata/acceptance/scripts/preinstall.sh
   postinstall: ./testdata/acceptance/scripts/postinstall.sh

--- a/testdata/acceptance/core.complex.yaml
+++ b/testdata/acceptance/core.complex.yaml
@@ -21,7 +21,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/acceptance/folder/*
   dst: /usr/share/whatever/folder
 - src: ./testdata/whatever.conf

--- a/testdata/acceptance/core.env-var-version.yaml
+++ b/testdata/acceptance/core.env-var-version.yaml
@@ -19,7 +19,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/acceptance/folder/**/*
   dst: /usr/share/whatever/folder/
 - src: ./testdata/whatever.conf

--- a/testdata/acceptance/core.min.yaml
+++ b/testdata/acceptance/core.min.yaml
@@ -5,4 +5,4 @@ license: MIT
 maintainer: "Foo Bar"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake

--- a/testdata/acceptance/core.overrides.yaml
+++ b/testdata/acceptance/core.overrides.yaml
@@ -19,7 +19,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/acceptance/folder/*
   dst: /usr/share/whatever/folder
 - src: ./testdata/whatever.conf

--- a/testdata/acceptance/core.signed.yaml
+++ b/testdata/acceptance/core.signed.yaml
@@ -8,7 +8,7 @@ vendor: "FooBarCorp"
 homepage: "http://example.com"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 deb:
   signature:
     key_file: ./internal/sign/testdata/privkey_unprotected.asc

--- a/testdata/acceptance/core.simple.yaml
+++ b/testdata/acceptance/core.simple.yaml
@@ -12,7 +12,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/whatever.conf
   dst: /etc/foo/whatever.conf
   type: config

--- a/testdata/acceptance/core.withchangelog.yaml
+++ b/testdata/acceptance/core.withchangelog.yaml
@@ -13,7 +13,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/whatever.conf
   dst: /etc/foo/whatever.conf
   type: config

--- a/testdata/acceptance/deb.debsign.sign.yaml
+++ b/testdata/acceptance/deb.debsign.sign.yaml
@@ -8,7 +8,7 @@ vendor: "FooBarCorp"
 homepage: "http://example.com"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 deb:
   signature:
     method: debsign

--- a/testdata/acceptance/deb.dockerfile
+++ b/testdata/acceptance/deb.dockerfile
@@ -16,12 +16,12 @@ RUN ls -l /path/to/symlink | grep "/path/to/symlink -> /etc/foo/whatever.conf"
 
 # ---- simple test ----
 FROM min AS simple
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN echo wat >> /etc/foo/whatever.conf
 RUN dpkg -r foo
 RUN test -f /etc/foo/whatever.conf
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 
 
 # ---- no-glob test ----
@@ -39,7 +39,7 @@ FROM min AS complex
 RUN apt-cache show /tmp/foo.deb | grep "Depends: bash"
 RUN apt-cache show /tmp/foo.deb | grep "Suggests: zsh"
 RUN apt-cache show /tmp/foo.deb | grep "Recommends: fish"
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN test -d /usr/share/whatever/
 RUN test -d /usr/share/whatever/folder
@@ -64,7 +64,7 @@ RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf
 RUN dpkg -r foo
 RUN test -f /etc/foo/whatever.conf
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 RUN test ! -f /usr/sbin/fake
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
@@ -95,7 +95,7 @@ RUN dpkg -i /tmp/foo.deb
 
 # ---- overrides test ----
 FROM min AS overrides
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN test ! -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
@@ -104,7 +104,7 @@ RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf
 RUN dpkg -r foo
 RUN test -f /etc/foo/whatever.conf
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 RUN test -f /tmp/preremove-proof
 RUN test ! -f /tmp/postremove-proof
 
@@ -161,11 +161,11 @@ RUN dpkg -i /tmp/foo.deb
 
 # ---- compression test ----
 FROM min AS compression
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN echo wat >> /etc/foo/whatever.conf
 RUN dpkg -r foo
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 
 # ---- upgrade test ----
 FROM test_base AS upgrade

--- a/testdata/acceptance/deb.dockerfile
+++ b/testdata/acceptance/deb.dockerfile
@@ -56,7 +56,7 @@ RUN test -f /etc/something/a
 RUN test -f /etc/something/b
 RUN test -d /etc/something/c
 RUN test -f /etc/something/c/d
-RUN test $(stat -c %a /usr/sbin/fake) -eq 4755
+RUN test $(stat -c %a /usr/bin/fake2) -eq 4755
 RUN test -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
 RUN test ! -f /tmp/preremove-proof
@@ -65,7 +65,7 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN dpkg -r foo
 RUN test -f /etc/foo/whatever.conf
 RUN test ! -f /usr/bin/fake
-RUN test ! -f /usr/sbin/fake
+RUN test ! -f /usr/bin/fake2
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
 RUN test ! -d /var/log/whatever

--- a/testdata/acceptance/deb.dpkg-sig.sign.yaml
+++ b/testdata/acceptance/deb.dpkg-sig.sign.yaml
@@ -8,7 +8,7 @@ vendor: "FooBarCorp"
 homepage: "http://example.com"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 deb:
   signature:
     method: dpkg-sig

--- a/testdata/acceptance/deb.gzip.compression.yaml
+++ b/testdata/acceptance/deb.gzip.compression.yaml
@@ -11,7 +11,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
   - src: ./testdata/fake
-    dst: /usr/local/bin/fake
+    dst: /usr/bin/fake
   - src: ./testdata/whatever.conf
     dst: /etc/foo/whatever.conf
     type: config

--- a/testdata/acceptance/deb.none.compression.yaml
+++ b/testdata/acceptance/deb.none.compression.yaml
@@ -11,7 +11,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
   - src: ./testdata/fake
-    dst: /usr/local/bin/fake
+    dst: /usr/bin/fake
   - src: ./testdata/whatever.conf
     dst: /etc/foo/whatever.conf
     type: config

--- a/testdata/acceptance/deb.rules.yaml
+++ b/testdata/acceptance/deb.rules.yaml
@@ -11,7 +11,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/whatever.conf
   dst: /etc/foo/whatever.conf
   type: config

--- a/testdata/acceptance/deb.triggers.yaml
+++ b/testdata/acceptance/deb.triggers.yaml
@@ -7,7 +7,7 @@ vendor: "foobar"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 scripts:
   postinstall: ./testdata/acceptance/scripts/postinstall_trigger.sh
 deb:

--- a/testdata/acceptance/deb.xz.compression.yaml
+++ b/testdata/acceptance/deb.xz.compression.yaml
@@ -11,7 +11,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
   - src: ./testdata/fake
-    dst: /usr/local/bin/fake
+    dst: /usr/bin/fake
   - src: ./testdata/whatever.conf
     dst: /etc/foo/whatever.conf
     type: config

--- a/testdata/acceptance/rpm.dockerfile
+++ b/testdata/acceptance/rpm.dockerfile
@@ -55,7 +55,7 @@ RUN test -f /etc/something/a
 RUN test -f /etc/something/b
 RUN test -d /etc/something/c
 RUN test -f /etc/something/c/d
-RUN test $(stat -c %a /usr/sbin/fake) -eq 4755
+RUN test $(stat -c %a /usr/bin/fake2) -eq 4755
 RUN test -f /tmp/preinstall-proof
 RUN test -f /tmp/postinstall-proof
 RUN test -f /tmp/pretrans-proof
@@ -66,7 +66,7 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN rpm -e foo
 RUN test -f /etc/foo/whatever.conf.rpmsave
 RUN test ! -f /usr/bin/fake
-RUN test ! -f /usr/sbin/fake
+RUN test ! -f /usr/bin/fake2
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
 RUN test ! -d /var/log/whatever

--- a/testdata/acceptance/rpm.dockerfile
+++ b/testdata/acceptance/rpm.dockerfile
@@ -16,12 +16,12 @@ RUN ls -l /path/to/symlink | grep "/path/to/symlink -> /etc/foo/whatever.conf"
 
 # ---- simple test ----
 FROM min AS simple
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN echo wat >> /etc/foo/whatever.conf
 RUN rpm -e foo
 RUN test -f /etc/foo/whatever.conf.rpmsave
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 
 
 # ---- no-glob test ----
@@ -39,7 +39,7 @@ FROM min AS complex
 RUN test "$(rpm -qp --recommends /tmp/foo.rpm)" = "fish"
 RUN test "$(rpm -qp --suggests /tmp/foo.rpm)" = "zsh"
 RUN test "$(rpm -qp --requires /tmp/foo.rpm)" = "bash"
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN test -d /usr/share/whatever/folder
 RUN test -f /usr/share/whatever/folder/file1
@@ -65,7 +65,7 @@ RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf
 RUN rpm -e foo
 RUN test -f /etc/foo/whatever.conf.rpmsave
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 RUN test ! -f /usr/sbin/fake
 RUN test -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
@@ -94,7 +94,7 @@ RUN yum install -y foo
 
 # ---- overrides test ----
 FROM min AS overrides
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN test -d /usr/share/whatever/folder
 RUN test -f /usr/share/whatever/folder/file1
@@ -109,7 +109,7 @@ RUN test ! -f /tmp/postremove-proof
 RUN echo wat >> /etc/foo/whatever.conf
 RUN rpm -e foo
 RUN test -f /etc/foo/whatever.conf.rpmsave
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 RUN test ! -f /tmp/preremove-proof
 RUN test -f /tmp/postremove-proof
 
@@ -150,12 +150,12 @@ RUN rpm -q foo --changelog | grep -E "^- note 3$"
 FROM min AS compression
 ARG compression
 RUN test "${compression}" = "$(rpm -qp --qf '%{PAYLOADCOMPRESSOR}' /tmp/foo.rpm)"
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN echo wat >> /etc/foo/whatever.conf
 RUN rpm -e foo
 RUN test -f /etc/foo/whatever.conf.rpmsave
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 
 # ---- upgrade test ----
 FROM test_base AS upgrade
@@ -197,12 +197,12 @@ RUN cat /etc/noreplace.conf.rpmnew | grep foo=baz
 
 # ---- release test ----
 FROM min AS release
-RUN test -e /usr/local/bin/fake
+RUN test -e /usr/bin/fake
 RUN test -f /etc/foo/whatever.conf
 RUN echo wat >> /etc/foo/whatever.conf
 RUN rpm -e foo
 RUN test -f /etc/foo/whatever.conf.rpmsave
-RUN test ! -f /usr/local/bin/fake
+RUN test ! -f /usr/bin/fake
 
 # ---- directories test ----
 FROM test_base AS directories

--- a/testdata/acceptance/rpm.gzip.compression.yaml
+++ b/testdata/acceptance/rpm.gzip.compression.yaml
@@ -11,7 +11,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/whatever.conf
   dst: /etc/foo/whatever.conf
   type: config

--- a/testdata/acceptance/rpm.lzma.compression.yaml
+++ b/testdata/acceptance/rpm.lzma.compression.yaml
@@ -11,7 +11,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/whatever.conf
   dst: /etc/foo/whatever.conf
   type: config

--- a/testdata/acceptance/rpm.release.yaml
+++ b/testdata/acceptance/rpm.release.yaml
@@ -12,7 +12,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/whatever.conf
   dst: /etc/foo/whatever.conf
   type: config

--- a/testdata/acceptance/rpm.xz.compression.yaml
+++ b/testdata/acceptance/rpm.xz.compression.yaml
@@ -11,7 +11,7 @@ homepage: "https://foobar.org"
 license: "MIT"
 contents:
 - src: ./testdata/fake
-  dst: /usr/local/bin/fake
+  dst: /usr/bin/fake
 - src: ./testdata/whatever.conf
   dst: /etc/foo/whatever.conf
   type: config

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -151,7 +151,7 @@ conflicts:
 contents:
   # Basic file that applies to all packagers
   - src: path/to/local/foo
-    dst: /usr/local/bin/foo
+    dst: /usr/bin/foo
 
   # Simple config file
   - src: path/to/local/foo.conf
@@ -164,8 +164,8 @@ contents:
   - src: path/to/local/*.1.gz
     dst: /usr/share/man/man1/
 
-  # Simple symlink at /usr/local/bin/foo which points to /sbin/foo, which is
-  # the same behaviour as `ln -s /sbin/foo /usr/local/bin/foo`.
+  # Simple symlink at /usr/bin/foo which points to /sbin/foo, which is
+  # the same behaviour as `ln -s /sbin/foo /usr/bin/foo`.
   #
   # This also means that both "src" and "dst" are paths inside the package (or
   # rather paths in the file system where the package will be installed) and
@@ -218,7 +218,7 @@ contents:
   # than 'root') has to be always specified manually in 'file_info' as it will not be copied
   # from the 'src' file.
   - src: path/to/foo
-    dst: /usr/local/foo
+    dst: /usr/share/foo
     file_info:
       # Make sure that the mode is specified in octal, e.g. 0644 instead of 644.
       mode: 0644


### PR DESCRIPTION
Examples, tests and docs often refer to /usr/local/bin, which should only be used for things compiled locally, which is not the case of installed packages.

Changed that to /usr/bin, and also some usages of things like /usr/something to /usr/share/something.
