### PR TITLE
feat: expand variables in platform field

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -108,6 +108,9 @@ func (*Apk) ConventionalExtension() string {
 
 // Package writes a new apk package to the given writer using the given info.
 func (*Apk) Package(info *nfpm.Info, apk io.Writer) (err error) {
+	if info.Platform != "linux" {
+		return fmt.Errorf("invalid platform: %s", info.Platform)
+	}
 	info = ensureValidArch(info)
 	if err = info.Validate(); err != nil {
 		return err

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -174,6 +174,15 @@ func TestDefaultWithArch(t *testing.T) {
 	}
 }
 
+func TestApkPlatform(t *testing.T) {
+	f, err := os.CreateTemp("", "test*.apk")
+	require.NoError(t, err)
+	info := exampleInfo()
+	info.Platform = "darwin"
+	err = Default.Package(info, f)
+	require.Error(t, err)
+}
+
 func TestNoInfo(t *testing.T) {
 	err := Default.Package(nfpm.WithDefaults(&nfpm.Info{}), io.Discard)
 	require.Error(t, err)

--- a/arch/arch.go
+++ b/arch/arch.go
@@ -115,6 +115,10 @@ func isOneOf(r rune, rr ...rune) bool {
 
 // Package writes a new archlinux package to the given writer using the given info.
 func (ArchLinux) Package(info *nfpm.Info, w io.Writer) error {
+	if info.Platform != "linux" {
+		return fmt.Errorf("invalid platform: %s", info.Platform)
+	}
+	info = ensureValidArch(info)
 	if err := info.Validate(); err != nil {
 		return err
 	}

--- a/arch/arch_test.go
+++ b/arch/arch_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -97,6 +98,15 @@ func TestArch(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestArchPlatform(t *testing.T) {
+	f, err := os.CreateTemp("", "test*.pkg.tar.zstd")
+	require.NoError(t, err)
+	info := exampleInfo()
+	info.Platform = "darwin"
+	err = Default.Package(info, f)
+	require.Error(t, err)
 }
 
 func TestArchNoFiles(t *testing.T) {

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -779,7 +779,7 @@ Version: {{ if .Info.Epoch}}{{ .Info.Epoch }}:{{ end }}{{.Info.Version}}
          {{- if .Info.Release}}-{{ .Info.Release }}{{- end }}
 Section: {{.Info.Section}}
 Priority: {{.Info.Priority}}
-Architecture: {{.Info.Arch}}
+Architecture: {{ if ne .Info.Platform "linux"}}{{ .Info.Platform }}-{{ end }}{{.Info.Arch}}
 {{- /* Optional fields */ -}}
 {{- if .Info.Maintainer}}
 Maintainer: {{.Info.Maintainer}}

--- a/nfpm.go
+++ b/nfpm.go
@@ -177,6 +177,7 @@ func (c *Config) expandEnvVars() {
 	c.Info.Release = os.Expand(c.Info.Release, c.envMappingFunc)
 	c.Info.Version = os.Expand(c.Info.Version, c.envMappingFunc)
 	c.Info.Prerelease = os.Expand(c.Info.Prerelease, c.envMappingFunc)
+	c.Info.Platform = os.Expand(c.Info.Platform, c.envMappingFunc)
 	c.Info.Arch = os.Expand(c.Info.Arch, c.envMappingFunc)
 	for or := range c.Overrides {
 		c.Overrides[or].Conflicts = c.expandEnvVarsStringSlice(c.Overrides[or].Conflicts)

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -244,12 +244,28 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		debPass         = "password123"
 		rpmPass         = "secret"
 		apkPass         = "foobar"
+		platform        = "linux"
+		arch            = "amd64"
 		release         = "3"
 		version         = "1.0.0"
 		vendor          = "GoReleaser"
 		packager        = "nope"
 		maintainerEmail = "nope@example.com"
 	)
+
+	t.Run("platform", func(t *testing.T) {
+		t.Setenv("OS", platform)
+		info, err := nfpm.Parse(strings.NewReader("name: foo\nplatform: $OS"))
+		require.NoError(t, err)
+		require.Equal(t, platform, info.Platform)
+	})
+
+	t.Run("arch", func(t *testing.T) {
+		t.Setenv("ARCH", arch)
+		info, err := nfpm.Parse(strings.NewReader("name: foo\narch: $ARCH"))
+		require.NoError(t, err)
+		require.Equal(t, arch, info.Arch)
+	})
 
 	t.Run("version", func(t *testing.T) {
 		os.Clearenv()

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -106,6 +106,14 @@ func TestRPM(t *testing.T) {
 	rpm, err := rpmutils.ReadRpm(file)
 	require.NoError(t, err)
 
+	os, err := rpm.Header.GetString(rpmutils.OS)
+	require.NoError(t, err)
+	require.Equal(t, "linux", os)
+
+	arch, err := rpm.Header.GetString(rpmutils.ARCH)
+	require.NoError(t, err)
+	require.Equal(t, archToRPM["amd64"], arch)
+
 	version, err := rpm.Header.GetString(rpmutils.VERSION)
 	require.NoError(t, err)
 	require.Equal(t, "1.0.0", version)
@@ -132,6 +140,14 @@ func TestRPM(t *testing.T) {
 	description, err := rpm.Header.GetString(rpmutils.DESCRIPTION)
 	require.NoError(t, err)
 	require.Equal(t, "Foo does things", description)
+}
+
+func TestRPMPlatform(t *testing.T) {
+	f, err := os.CreateTemp("", "test*.rpm")
+	require.NoError(t, err)
+	info := exampleInfo()
+	info.Platform = "darwin"
+	require.NoError(t, Default.Package(info, f))
 }
 
 func TestRPMGroup(t *testing.T) {

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -19,7 +19,7 @@ arch: amd64
 
 # Platform.
 # This will expand any env var you set in the field, e.g. version: ${GOOS}
-# This is only used by the rpm packager.
+# This is only used by the rpm and deb packagers.
 # Examples: `linux` (default), `darwin`
 platform: linux
 

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -18,6 +18,7 @@ name: foo
 arch: amd64
 
 # Platform.
+# This will expand any env var you set in the field, e.g. version: ${GOOS}
 # This is only used by the rpm packager.
 # Examples: `linux` (default), `darwin`
 platform: linux


### PR DESCRIPTION
Surprising that GOARCH was expanded, but GOOS was not.
More consistent to expand both of them the same way ?

Implement platform for deb packager, goes into Architecture.    
Validate that the platform is "linux", for Alpine and Arch.

Closes #600 