### PR TITLE
fix(deb): check for empty provides value

### DIFF
--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -116,6 +116,13 @@ func TestDebPlatform(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDebEmptyProvides(t *testing.T) {
+	info := exampleInfo()
+	info.Provides = append(info.Provides, "")
+	err := Default.Package(info, io.Discard)
+	require.Equal(t, err, ErrInvalidProvides)
+}
+
 func extractDebArchitecture(deb *bytes.Buffer) string {
 	for _, s := range strings.Split(deb.String(), "\n") {
 		if strings.Contains(s, "Architecture: ") {


### PR DESCRIPTION
This PR adds a check to the deb packager that returns an error if the `Provides` field contains an empty string. This check is needed because `dpkg` cannot parse provides lines with empty strings, and returns the following error when trying to install such a package:

```
E: Problem parsing Provides line
E: Error occurred while processing espanso-bin (NewVersion2)
E: Problem with MergeList /home/arsen/.cache/lure/pkgs/espanso-bin/espanso-bin_2.1.8-1_amd64.deb
E: The package lists or status file could not be parsed or opened.
```

This doesn't appear to be an issue with other packagers, so I've only added it for deb.