### PR TITLE
feat: add zstd compression support for deb and rpm

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -135,7 +135,7 @@ func TestUpgrade(t *testing.T) {
 func TestRPMCompression(t *testing.T) {
 	t.Parallel()
 	format := "rpm"
-	compressFormats := []string{"gzip", "xz", "lzma"}
+	compressFormats := []string{"gzip", "xz", "lzma", "zstd"}
 	for _, arch := range formatArchs[format] {
 		for _, compFormat := range compressFormats {
 			func(t *testing.T, testCompFormat, testArch string) {
@@ -164,7 +164,7 @@ func TestRPMCompression(t *testing.T) {
 func TestDebCompression(t *testing.T) {
 	t.Parallel()
 	format := "deb"
-	compressFormats := []string{"gzip", "xz", "none"}
+	compressFormats := []string{"gzip", "xz", "zstd", "none"}
 	for _, arch := range formatArchs[format] {
 		for _, compFormat := range compressFormats {
 			func(t *testing.T, testCompFormat, testArch string) {
@@ -173,13 +173,20 @@ func TestDebCompression(t *testing.T) {
 					if testArch == "ppc64le" && os.Getenv("NO_TEST_PPC64LE") == "true" {
 						t.Skip("ppc64le arch not supported in pipeline")
 					}
+
+					target := "compression"
+					if testCompFormat == "zstd" {
+						// we can remove this exception as soon as the debian image supports zstd
+						target = "zstdcompression"
+					}
+
 					accept(t, acceptParms{
 						Name:   fmt.Sprintf("%s_compression_%s", testCompFormat, testArch),
 						Conf:   fmt.Sprintf("deb.%s.compression.yaml", testCompFormat),
 						Format: format,
 						Docker: dockerParams{
 							File:   fmt.Sprintf("%s.dockerfile", format),
-							Target: "compression",
+							Target: target,
 							Arch:   testArch,
 						},
 					})

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -21,6 +21,7 @@ import (
 	"github.com/goreleaser/nfpm/v2/deprecation"
 	"github.com/goreleaser/nfpm/v2/files"
 	"github.com/goreleaser/nfpm/v2/internal/sign"
+	"github.com/klauspost/compress/zstd"
 	gzip "github.com/klauspost/pgzip"
 	"github.com/ulikunitz/xz"
 )
@@ -312,6 +313,12 @@ func createDataTarball(info *nfpm.Info) (dataTarBall, md5sums []byte,
 			return nil, nil, 0, "", err
 		}
 		name = "data.tar.xz"
+	case "zstd":
+		dataTarballWriteCloser, err = zstd.NewWriter(&dataTarball)
+		if err != nil {
+			return nil, nil, 0, "", err
+		}
+		name = "data.tar.zst"
 	case "none":
 		dataTarballWriteCloser = nopCloser{Writer: &dataTarball}
 		name = "data.tar"

--- a/testdata/acceptance/deb.dockerfile
+++ b/testdata/acceptance/deb.dockerfile
@@ -173,6 +173,20 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN dpkg -r foo
 RUN test ! -f /usr/bin/fake
 
+# ---- zstdcompression test ----
+# we can use the regular compression image as
+# soon as zstd is supported on debian
+FROM ubuntu AS zstdcompression
+ARG package
+RUN echo "${package}"
+COPY ${package} /tmp/foo.deb
+RUN dpkg -i /tmp/foo.deb
+RUN test -e /usr/bin/fake
+RUN test -f /etc/foo/whatever.conf
+RUN echo wat >> /etc/foo/whatever.conf
+RUN dpkg -r foo
+RUN test ! -f /usr/bin/fake
+
 # ---- upgrade test ----
 FROM test_base AS upgrade
 ARG oldpackage

--- a/testdata/acceptance/deb.zstd.compression.yaml
+++ b/testdata/acceptance/deb.zstd.compression.yaml
@@ -1,0 +1,19 @@
+name: "foo"
+arch: "${BUILD_ARCH}"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+contents:
+  - src: ./testdata/fake
+    dst: /usr/bin/fake
+  - src: ./testdata/whatever.conf
+    dst: /etc/foo/whatever.conf
+    type: config
+deb:
+  compression: "zstd"

--- a/testdata/acceptance/rpm.zstd.compression.yaml
+++ b/testdata/acceptance/rpm.zstd.compression.yaml
@@ -1,0 +1,19 @@
+name: "foo"
+arch: "${BUILD_ARCH}"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+contents:
+- src: ./testdata/fake
+  dst: /usr/bin/fake
+- src: ./testdata/whatever.conf
+  dst: /etc/foo/whatever.conf
+  type: config
+rpm:
+  compression: "zstd"

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -298,8 +298,8 @@ rpm:
   # This will expand any env var you set in the field, e.g. packager: ${PACKAGER}
   packager: GoReleaser <staff@goreleaser.com>
 
-  # Compression algorithm (gzip (default), lzma or xz).
-  compression: lzma
+  # Compression algorithm (gzip (default), zstd, lzma or xz).
+  compression: zstd
 
   # The package is signed if a key_file is set
   signature:
@@ -349,8 +349,8 @@ deb:
   breaks:
     - some-package
 
-  # Compression algorithm (gzip (default), xz or none).
-  compression: xz
+  # Compression algorithm (gzip (default), zstd, xz or none).
+  compression: zstd
 
   # The package is signed if a key_file is set
   signature:


### PR DESCRIPTION
This PR adds `zstd` compression support for `deb` and `rpm`. For `deb`, an exception for the acceptance tests was needed as `zstd` is not yet supported in the debian base image. Due to `rpmpack`, `zstd` was already supported for `rpms` and we already tested it in our `rpm` tests but it was not documented, yet.