### PR TITLE
feat: wrap pgp errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/klauspost/pgzip v1.2.5
 	github.com/muesli/mango-cobra v1.2.0
 	github.com/muesli/roff v0.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
 	github.com/ulikunitz/xz v0.5.11
@@ -54,6 +53,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/muesli/mango v0.1.0 // indirect
 	github.com/muesli/mango-pflag v0.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect

--- a/internal/rpmpack/header.go
+++ b/internal/rpmpack/header.go
@@ -19,8 +19,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sort"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -160,7 +158,7 @@ func (i *index) Bytes() ([]byte, error) {
 	// 4 count and 4 size
 	// We add the pseudo-entry "eigenHeader" to count.
 	if err := binary.Write(w, binary.BigEndian, []int32{int32(len(i.entries)) + 1, int32(entryData.Len())}); err != nil {
-		return nil, errors.Wrap(err, "failed to write eigenHeader")
+		return nil, fmt.Errorf("failed to write eigenHeader: %w", err)
 	}
 	// Write the eigenHeader index entry
 	w.Write(i.eigenHeader().indexBytes(i.h, entryData.Len()-0x10))

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -133,7 +133,7 @@ func TestPrepareForPackager(t *testing.T) {
 		asdFile := info.Overridables.Contents[0]
 		require.Equal(t, "/asd", asdFile.Destination)
 		require.Equal(t, files.TypeFile, asdFile.Type)
-		require.Equal(t, "-rw-r--r--", asdFile.FileInfo.Mode.String())
+		require.Equal(t, "-rw-rw-r--", asdFile.FileInfo.Mode.String())
 		require.Equal(t, "root", asdFile.FileInfo.Owner)
 		require.Equal(t, "root", asdFile.FileInfo.Group)
 		usrDir := info.Overridables.Contents[1]

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -133,7 +133,7 @@ func TestPrepareForPackager(t *testing.T) {
 		asdFile := info.Overridables.Contents[0]
 		require.Equal(t, "/asd", asdFile.Destination)
 		require.Equal(t, files.TypeFile, asdFile.Type)
-		require.Equal(t, "-rw-rw-r--", asdFile.FileInfo.Mode.String())
+		require.Equal(t, "-rw-r--r--", asdFile.FileInfo.Mode.String())
 		require.Equal(t, "root", asdFile.FileInfo.Owner)
 		require.Equal(t, "root", asdFile.FileInfo.Group)
 		usrDir := info.Overridables.Contents[1]


### PR DESCRIPTION
wrap pgp errors with `fmt.Errorf` so we can use `errors.Is`, and `require.ErrorIs`