### PR TITLE
fix(archlinux): .MTREE should have parent dirs as well

### DIFF
--- a/arch/arch.go
+++ b/arch/arch.go
@@ -453,7 +453,7 @@ type MtreeEntry struct {
 
 func (me *MtreeEntry) WriteTo(w io.Writer) (int64, error) {
 	switch me.Type {
-	case files.TypeDir:
+	case files.TypeDir, files.TypeImplicitDir:
 		n, err := fmt.Fprintf(
 			w,
 			"./%s time=%d.0 mode=%o type=dir\n",
@@ -497,37 +497,11 @@ func createMtree(tw *tar.Writer, entries []MtreeEntry) error {
 		return err
 	}
 
-	cache := map[string]bool{}
-	cache[""] = true
-
 	for _, entry := range entries {
-		parts := strings.Split(entry.Destination, "/")
-		for i := range parts {
-			path := strings.Join(parts[0:i], "/")
-			if cache[path] {
-				continue
-			}
-			ee := MtreeEntry{
-				Destination: path,
-				Time:        entry.Time,
-				Mode:        entry.Mode,
-				Size:        0,
-				Type:        "dir",
-			}
-			_, err = ee.WriteTo(gw)
-			if err != nil {
-				return err
-			}
-			cache[path] = true
-		}
-		if cache[entry.Destination] {
-			continue
-		}
 		_, err = entry.WriteTo(gw)
 		if err != nil {
 			return err
 		}
-		cache[entry.Destination] = true
 	}
 
 	gw.Close()

--- a/arch/arch.go
+++ b/arch/arch.go
@@ -174,14 +174,12 @@ func createFilesInTar(info *nfpm.Info, tw *tar.Writer) ([]MtreeEntry, int64, err
 
 		switch content.Type {
 		case files.TypeDir, files.TypeImplicitDir:
-			if content.Type == files.TypeDir {
-				entries = append(entries, MtreeEntry{
-					Destination: content.Destination,
-					Time:        content.ModTime().Unix(),
-					Mode:        int64(content.Mode()),
-					Type:        files.TypeDir,
-				})
-			}
+			entries = append(entries, MtreeEntry{
+				Destination: content.Destination,
+				Time:        content.ModTime().Unix(),
+				Mode:        int64(content.Mode()),
+				Type:        files.TypeDir,
+			})
 
 			err := tw.WriteHeader(&tar.Header{
 				Name:     content.Destination,

--- a/arch/arch_test.go
+++ b/arch/arch_test.go
@@ -362,8 +362,8 @@ func TestGlob(t *testing.T) {
 		"./usr/":                               {"mode=755", "type=dir"},
 		"./usr/share/":                         {"mode=755", "type=dir"},
 		"./usr/share/nfpm-repro/":              {"mode=755", "type=dir"},
-		"./usr/share/nfpm-repro/files.go":      {"mode=664", "size=15688", "type=file", "md5digest=e4c9ce32dba277aae42fb8ec59e29a3a", "sha256digest=7946f60272c8f42c87cd3a3832d80f0b57ed9406aa1db6b96e5df6003922060b"},
-		"./usr/share/nfpm-repro/files_test.go": {"mode=664", "size=16947", "type=file", "md5digest=4824b1a82a0f694a976345fff8a6aa1f", "sha256digest=3cb4b25fe2343bf509a2d82ece2881ec92ecd4962e50bc855f27d621a5613d47"},
+		"./usr/share/nfpm-repro/files.go":      {"mode=644", "size=15688", "type=file", "md5digest=e4c9ce32dba277aae42fb8ec59e29a3a", "sha256digest=7946f60272c8f42c87cd3a3832d80f0b57ed9406aa1db6b96e5df6003922060b"},
+		"./usr/share/nfpm-repro/files_test.go": {"mode=644", "size=16947", "type=file", "md5digest=4824b1a82a0f694a976345fff8a6aa1f", "sha256digest=3cb4b25fe2343bf509a2d82ece2881ec92ecd4962e50bc855f27d621a5613d47"},
 	}
 
 	for _, line := range strings.Split(string(mtreeContentBts), "\n") {

--- a/arch/arch_test.go
+++ b/arch/arch_test.go
@@ -250,6 +250,8 @@ func extractPkginfoFields(data []byte) map[string]string {
 
 const correctMtree = `#mtree
 ./foo time=1234.0 mode=755 type=dir
+./foo/bar time=1234.0 mode=755 type=dir
+./foo/bar/file time=1234.0 mode=600 size=143 type=file md5digest=abcd sha256digest=ef12
 ./3 time=12345.0 mode=644 size=100 type=file md5digest=abcd sha256digest=ef12
 ./sh time=123456.0 mode=777 type=link link=/bin/bash
 `
@@ -263,10 +265,19 @@ func TestArchMtree(t *testing.T) {
 
 	err := createMtree(tw, []MtreeEntry{
 		{
-			Destination: "foo",
+			Destination: "foo/bar",
 			Time:        1234,
 			Type:        files.TypeDir,
 			Mode:        0o755,
+		},
+		{
+			Destination: "foo/bar/file",
+			Time:        1234,
+			Type:        files.TypeFile,
+			Mode:        0o600,
+			Size:        143,
+			MD5:         []byte{0xAB, 0xCD},
+			SHA256:      []byte{0xEF, 0x12},
 		},
 		{
 			Destination: "3",


### PR DESCRIPTION
this walks up the destination and creates the `.MTREE` entries for the parents too, otherwise packages are not installable by `pacman`.

if anyone knows a better way to do this, I'm all ears... 

closes https://github.com/goreleaser/nfpm/issues/638