### PR TITLE
fix: md5sums entries and lintian errors/warnings

### DIFF
--- a/testdata/acceptance/core.withchangelog.yaml
+++ b/testdata/acceptance/core.withchangelog.yaml
@@ -4,16 +4,25 @@ platform: "linux"
 changelog: "./testdata/changelog.yaml"
 version: "v1.2.3"
 release: "simple"
-maintainer: "Foo Bar"
+maintainer: "Foo Bar <foo@example.org>"
 description: |
-  Foo bar
-    Multiple lines
+  Program foo bar
+  Multiple lines
 vendor: "foobar"
 homepage: "https://foobar.org"
 license: "MIT"
+section: misc
 contents:
 - src: ./testdata/fake
   dst: /usr/bin/fake
+  file_info:
+    mode: 0755
 - src: ./testdata/whatever.conf
   dst: /etc/foo/whatever.conf
   type: config
+  file_info:
+    mode: 0644
+- src: ./testdata/copyright
+  dst: /usr/share/doc/foo/
+  file_info:
+    mode: 0644

--- a/testdata/acceptance/deb.dockerfile
+++ b/testdata/acceptance/deb.dockerfile
@@ -140,8 +140,20 @@ RUN lintian /tmp/foo.deb > lintian.out
 RUN test $(grep -c 'debian-changelog-file-missing-or-wrong-name' lintian.out) = 0
 RUN test $(grep -c 'changelog-not-compressed-with-max-compression' lintian.out) = 0
 RUN test $(grep -c 'unknown-control-file' lintian.out) = 0
-# TODO: RUN test $(grep -c 'package-contains-timestamped-gzip' lintian.out) = 0
-# TODO: RUN test $(grep -c 'syntax-error-in-debian-changelog' lintian.out) = 0
+RUN test $(grep -c 'package-contains-timestamped-gzip' lintian.out) = 0
+RUN test $(grep -c 'md5sums-lists-nonexistent-file' lintian.out) = 0
+RUN test $(grep -c 'file-missing-in-md5sums' lintian.out) = 0
+RUN test $(grep -c 'syntax-error-in-debian-changelog' lintian.out) = 0
+RUN test $(grep -c 'no-copyright-file' lintian.out) = 0
+RUN test $(grep -c 'executable-is-not-world-readable' lintian.out) = 0
+RUN test $(grep -c 'non-standard-executable-perm' lintian.out) = 0
+RUN test $(grep -c 'non-standard-file-perm' lintian.out) = 0
+RUN test $(grep -c 'unknown-section' lintian.out) = 0
+RUN test $(grep -c 'empty-field' lintian.out) = 0
+RUN test $(grep -c 'syntax-error-in-debian-changelog' lintian.out) = 0
+RUN test $(grep -c 'malformed-contact' lintian.out) = 0
+RUN test $(grep -c 'description-starts-with-package-name' lintian.out) = 0
+RUN test $(grep -c 'description-starts-with-leading-spaces' lintian.out) = 0
 
 # ---- rules test ----
 FROM min AS rules

--- a/testdata/changelog.yaml
+++ b/testdata/changelog.yaml
@@ -1,4 +1,8 @@
-- semver: "1.1.0-1"
+- deb:
+    urgency: medium
+    distributions:
+      - bookworm
+  semver: "1.1.0-1"
   date: "2009-12-08T22:00:00Z"
   packager: "Carlos A Becker <pkg@carlosbecker.com>"
   urgency: "low"
@@ -7,7 +11,11 @@
     - note: "note 1"
     - note: "note 2"
 
-- semver: "1.0.0-1"
+- deb:
+    urgency: medium
+    distributions:
+      - bookworm
+  semver: "1.0.0-1"
   date: "2009-11-10T23:00:00Z"
   packager: "Carlos A Becker <pkg@carlosbecker.com>"
   urgency: "low"

--- a/testdata/copyright
+++ b/testdata/copyright
@@ -1,0 +1,5 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Files:
+ *
+Copyright: 2023 The foo bar
+License: MIT


### PR DESCRIPTION
- Missing trailing ./ in md5sums for changelog.Debian.gz caused md5sums-lists-nonexistent-file and file-missing-in-md5sums and is fixed using files.AsExplicitRelativePath.
- Adding copyright file fixes no-copyright-file.
- Set file_info fixes executable-is-not-world-readable, non-standard-executable-perm, non-standard-file-perm.
- Adding section fixes unknown-section, empty-field.
- Using standard compress/gzip module fixes package-contains-timestamped-gzip, because klauspost/pgzip does not support empty mod time.
- Adding urgency and distribution in changelog fixes syntax-error-in-debian-changelog.
- Adding mail address to maintainer fixes malformed-contact.
- Correcting description fixes description-starts-with-package-name and description-starts-with-leading-spaces.