### PR TITLE
feat: expand environment variables in deb fields values

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -229,6 +229,11 @@ func (c *Config) expandEnvVars() {
 
 	// RPM specific
 	c.Info.RPM.Packager = os.Expand(c.RPM.Packager, c.envMappingFunc)
+
+	// Deb specific
+	for k, v := range c.Info.Deb.Fields {
+		c.Info.Deb.Fields[k] = os.Expand(v, c.envMappingFunc)
+	}
 }
 
 // Info contains information about a single package.

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -366,6 +366,7 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		vendor          = "GoReleaser"
 		packager        = "nope"
 		maintainerEmail = "nope@example.com"
+		vcsURL          = "https://github.com/goreleaser/nfpm.git"
 	)
 
 	t.Run("platform", func(t *testing.T) {
@@ -485,6 +486,18 @@ overrides:
 		require.Equal(t, "package (= 1.0.0)", info.Overrides["deb"].Depends[0])
 		require.Len(t, info.Overrides["rpm"].Depends, 1)
 		require.Equal(t, "package = 1.0.0", info.Overrides["rpm"].Depends[0])
+	})
+
+	t.Run("deb fields", func(t *testing.T) {
+		t.Setenv("CI_REPOSITORY_URL", vcsURL)
+		info, err := nfpm.Parse(strings.NewReader(`
+name: foo
+deb:
+  fields:
+    Vcs-Git: ${CI_REPOSITORY_URL}
+`))
+		require.NoError(t, err)
+		require.Equal(t, vcsURL, info.Deb.Fields["Vcs-Git"])
 	})
 }
 

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -399,6 +399,7 @@ deb:
     key_id: bc8acdd415bd80b3
 
   # Additional fields for the control file. Empty fields are ignored.
+  # This will expand any env vars you set in the field values, e.g. Vcs-Git: ${CI_REPOSITORY_URL}
   fields:
     Bugs: https://github.com/goreleaser/nfpm/issues
 


### PR DESCRIPTION
This is convenient in CI, one real world example usage in tests and docs.

(FWIW, `CI_REPOSITORY_URL` is a predefined env var at least in GitLab CI.)