### PR TITLE
fix(golangci-lint): depguard (v2) config for >= 1.53

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,8 @@ linters-settings:
         yaml: snake
         json: snake
   depguard:
-     list-type: 'denylist'
-     packages-with-error-message:
-       - 'github.com/pkg/errors': 'use stdlib instead'
+    rules:
+      main:
+        deny:
+          - pkg: 'github.com/pkg/errors'
+            desc: 'use stdlib instead'


### PR DESCRIPTION
golangci-lint 1.53 upgrades depguard to v2, and per [their words](https://twitter.com/golangci/status/1664374779808284677),
> ⚠️WARNING⚠️
> depguard configuration has completely changed
