### PR TITLE
chore: remove space from asset name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,7 +80,7 @@ archives:
 - rlcp: true
   name_template: >-
       {{ .ProjectName }}_
-      {{ .Version }}_
+      {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
- https://github.com/goreleaser/nfpm/discussions/673

I checked GitHub Actions log, then it seems there is an space between `nfpm_` and `2.30.0`.

https://github.com/goreleaser/nfpm/actions/runs/5180574010/jobs/9334922406

```
• archives
    • creating                                       archive=dist/nfpm_ 2.30.0_Windows_arm64.zip
    • creating                                       archive=dist/nfpm_ 2.30.0_Windows_x86_64.zip
    • creating                                       archive=dist/nfpm_ 2.30.0_Linux_arm64.tar.gz
    • creating                                       archive=dist/nfpm_ 2.30.0_Linux_x86_[64](https://github.com/goreleaser/nfpm/actions/runs/5180574010/jobs/9334922406#step:13:65).tar.gz
    • creating                                       archive=dist/nfpm_ 2.30.0_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/nfpm_ 2.30.0_Darwin_arm64.tar.gz
```

https://pkg.go.dev/text/template#hdr-Text_and_spaces

I guess GitHub may convert spaces in asset names to periods.

## Test

I ran `goreleaser release --snapshot --clean` on my laptop and confirmed the bug has been fixed.

```sh
goreleaser release --snapshot --clean
```

AS IS

```
  • archives
    • creating                                       archive=dist/nfpm_ 2.30.0-SNAPSHOT-a72ecd2_Linux_x86_64.tar.gz
    • creating                                       archive=dist/nfpm_ 2.30.0-SNAPSHOT-a72ecd2_Windows_x86_64.zip
    • creating                                       archive=dist/nfpm_ 2.30.0-SNAPSHOT-a72ecd2_Darwin_arm64.tar.gz
    • creating                                       archive=dist/nfpm_ 2.30.0-SNAPSHOT-a72ecd2_Windows_arm64.zip
    • creating                                       archive=dist/nfpm_ 2.30.0-SNAPSHOT-a72ecd2_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/nfpm_ 2.30.0-SNAPSHOT-a72ecd2_Linux_arm64.tar.gz
```

TO BE

```
  • archives
    • creating                                       archive=dist/nfpm_2.30.0-SNAPSHOT-c4d9c64_Windows_arm64.zip
    • creating                                       archive=dist/nfpm_2.30.0-SNAPSHOT-c4d9c64_Linux_arm64.tar.gz
    • creating                                       archive=dist/nfpm_2.30.0-SNAPSHOT-c4d9c64_Windows_x86_64.zip
    • creating                                       archive=dist/nfpm_2.30.0-SNAPSHOT-c4d9c64_Darwin_arm64.tar.gz
    • creating                                       archive=dist/nfpm_2.30.0-SNAPSHOT-c4d9c64_Linux_x86_64.tar.gz
    • creating                                       archive=dist/nfpm_2.30.0-SNAPSHOT-c4d9c64_Darwin_x86_64.tar.gz
```