### PR TITLE
feat: expand env variables in homepage field

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -193,8 +193,9 @@ func (c *Config) expandEnvVars() {
 	c.Info.Provides = c.expandEnvVarsStringSlice(c.Info.Provides)
 	c.Info.Suggests = c.expandEnvVarsStringSlice(c.Info.Suggests)
 
-	// Maintainer and vendor fields
+	// Basic metadata fields
 	c.Info.Name = os.Expand(c.Info.Name, c.envMappingFunc)
+	c.Info.Homepage = os.Expand(c.Info.Homepage, c.envMappingFunc)
 	c.Info.Maintainer = os.Expand(c.Info.Maintainer, c.envMappingFunc)
 	c.Info.Vendor = os.Expand(c.Info.Vendor, c.envMappingFunc)
 

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -366,6 +366,7 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		vendor          = "GoReleaser"
 		packager        = "nope"
 		maintainerEmail = "nope@example.com"
+		homepage        = "https://nfpm.goreleaser.com"
 		vcsURL          = "https://github.com/goreleaser/nfpm.git"
 	)
 
@@ -417,6 +418,13 @@ maintainer: '"$GIT_COMMITTER_NAME" <$GIT_COMMITTER_EMAIL>'
 		info, err := nfpm.Parse(strings.NewReader("name: foo\nvendor: $VENDOR"))
 		require.NoError(t, err)
 		require.Equal(t, vendor, info.Vendor)
+	})
+
+	t.Run("homepage", func(t *testing.T) {
+		t.Setenv("CI_PROJECT_URL", homepage)
+		info, err := nfpm.Parse(strings.NewReader("name: foo\nhomepage: $CI_PROJECT_URL"))
+		require.NoError(t, err)
+		require.Equal(t, homepage, info.Homepage)
 	})
 
 	t.Run("global passphrase", func(t *testing.T) {

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -94,6 +94,7 @@ description: Sample package
 vendor: GoReleaser
 
 # Package's homepage.
+# This will expand any env var you set in the field, e.g. homepage: ${CI_PROJECT_URL}
 homepage: https://nfpm.goreleaser.com
 
 # License.


### PR DESCRIPTION
For example, GitLab CI has `CI_PROJECT_URL` which can be useful here.