### PR TITLE
test: signatures on centos 7 and 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ completions/
 cosign.*
 manpages
 output.json
+!acceptance_test.go

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -1,6 +1,3 @@
-//go:build acceptance
-// +build acceptance
-
 package nfpm_test
 
 import (
@@ -259,32 +256,53 @@ func TestDebSpecific(t *testing.T) {
 	}
 }
 
+func TestRpmCentosSign(t *testing.T) {
+	t.Parallel()
+	for _, os := range []string{"centos7", "centos8"} {
+		os := os
+		t.Run(fmt.Sprintf("rpm/signed/amd64/%s", os), func(t *testing.T) {
+			t.Parallel()
+			target := "signed"
+			accept(t, acceptParms{
+				Name:   fmt.Sprintf("sign_%s_amd64", os),
+				Conf:   "core.signed.yaml",
+				Format: "rpm",
+				Docker: dockerParams{
+					File:   fmt.Sprintf("rpm_%s.dockerfile", os),
+					Target: target,
+					Arch:   "amd64",
+				},
+			})
+		})
+	}
+}
+
 func TestDebSign(t *testing.T) {
 	t.Parallel()
 	for _, arch := range formatArchs["deb"] {
 		for _, sigtype := range []string{"dpkg-sig", "debsign"} {
-			func(t *testing.T, testSigtype, testArch string) {
-				t.Run(fmt.Sprintf("%s/%s", testArch, testSigtype), func(t *testing.T) {
-					target := "signed"
-					if testSigtype == "dpkg-sig" {
-						target = "dpkg-signed"
-					}
-					t.Parallel()
-					if testArch == "ppc64le" && os.Getenv("NO_TEST_PPC64LE") == "true" {
-						t.Skip("ppc64le arch not supported in pipeline")
-					}
-					accept(t, acceptParms{
-						Name:   fmt.Sprintf("%s_sign_%s", testSigtype, testArch),
-						Conf:   fmt.Sprintf("deb.%s.sign.yaml", testSigtype),
-						Format: "deb",
-						Docker: dockerParams{
-							File:   "deb.dockerfile",
-							Target: target,
-							Arch:   testArch,
-						},
-					})
+			testSigtype := sigtype
+			testArch := arch
+			t.Run(fmt.Sprintf("%s/%s", testArch, testSigtype), func(t *testing.T) {
+				t.Parallel()
+				target := "signed"
+				if testSigtype == "dpkg-sig" {
+					target = "dpkg-signed"
+				}
+				if testArch == "ppc64le" && os.Getenv("NO_TEST_PPC64LE") == "true" {
+					t.Skip("ppc64le arch not supported in pipeline")
+				}
+				accept(t, acceptParms{
+					Name:   fmt.Sprintf("%s_sign_%s", testSigtype, testArch),
+					Conf:   fmt.Sprintf("deb.%s.sign.yaml", testSigtype),
+					Format: "deb",
+					Docker: dockerParams{
+						File:   "deb.dockerfile",
+						Target: target,
+						Arch:   testArch,
+					},
 				})
-			}(t, sigtype, arch)
+			})
 		}
 	}
 }

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -258,7 +258,7 @@ func TestDebSpecific(t *testing.T) {
 
 func TestRpmCentosSign(t *testing.T) {
 	t.Parallel()
-	for _, os := range []string{"centos7", "centos8"} {
+	for _, os := range []string{"centos9", "centos8"} {
 		os := os
 		t.Run(fmt.Sprintf("rpm/signed/amd64/%s", os), func(t *testing.T) {
 			t.Parallel()

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -284,28 +284,28 @@ func TestDebSign(t *testing.T) {
 	t.Parallel()
 	for _, arch := range formatArchs["deb"] {
 		for _, sigtype := range []string{"dpkg-sig", "debsign"} {
-			testSigtype := sigtype
-			testArch := arch
-			t.Run(fmt.Sprintf("%s/%s", testArch, testSigtype), func(t *testing.T) {
-				t.Parallel()
-				target := "signed"
-				if testSigtype == "dpkg-sig" {
-					target = "dpkg-signed"
-				}
-				if testArch == "ppc64le" && os.Getenv("NO_TEST_PPC64LE") == "true" {
-					t.Skip("ppc64le arch not supported in pipeline")
-				}
-				accept(t, acceptParms{
-					Name:   fmt.Sprintf("%s_sign_%s", testSigtype, testArch),
-					Conf:   fmt.Sprintf("deb.%s.sign.yaml", testSigtype),
-					Format: "deb",
-					Docker: dockerParams{
-						File:   "deb.dockerfile",
-						Target: target,
-						Arch:   testArch,
-					},
+			func(t *testing.T, testSigtype, testArch string) {
+				t.Run(fmt.Sprintf("%s/%s", testArch, testSigtype), func(t *testing.T) {
+					t.Parallel()
+					target := "signed"
+					if testSigtype == "dpkg-sig" {
+						target = "dpkg-signed"
+					}
+					if testArch == "ppc64le" && os.Getenv("NO_TEST_PPC64LE") == "true" {
+						t.Skip("ppc64le arch not supported in pipeline")
+					}
+					accept(t, acceptParms{
+						Name:   fmt.Sprintf("%s_sign_%s", testSigtype, testArch),
+						Conf:   fmt.Sprintf("deb.%s.sign.yaml", testSigtype),
+						Format: "deb",
+						Docker: dockerParams{
+							File:   "deb.dockerfile",
+							Target: target,
+							Arch:   testArch,
+						},
+					})
 				})
-			})
+			}(t, sigtype, arch)
 		}
 	}
 }

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package nfpm_test
 
 import (

--- a/testdata/acceptance/rpm_centos7.dockerfile
+++ b/testdata/acceptance/rpm_centos7.dockerfile
@@ -1,0 +1,24 @@
+FROM dokken/centos-7 AS test_base
+ARG package
+RUN echo "${package}"
+COPY ${package} /tmp/foo.rpm
+
+
+
+# ---- signed test ----
+FROM test_base AS signed
+COPY keys/pubkey.asc /tmp/pubkey.asc
+RUN rpm --import /tmp/pubkey.asc
+RUN rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n'
+RUN rpm -K /tmp/foo.rpm
+RUN rpm -K /tmp/foo.rpm | grep -E "(?:pgp|digests signatures) OK"
+RUN rpm -vK /tmp/foo.rpm
+RUN rpm -vK /tmp/foo.rpm | grep "RSA/SHA256 Signature, key ID 15bd80b3: OK"
+
+# Test with a repo
+RUN yum install -y createrepo yum-utils
+RUN rm -rf /etc/yum.repos.d/*.repo
+COPY keys/test.rpm.repo /etc/yum.repos.d/test.rpm.repo
+RUN createrepo /tmp
+RUN yum install -y foo
+

--- a/testdata/acceptance/rpm_centos8.dockerfile
+++ b/testdata/acceptance/rpm_centos8.dockerfile
@@ -1,0 +1,22 @@
+FROM dokken/centos-8 AS test_base
+ARG package
+RUN echo "${package}"
+COPY ${package} /tmp/foo.rpm
+
+# ---- signed test ----
+FROM test_base AS signed
+COPY keys/pubkey.asc /tmp/pubkey.asc
+RUN rpm --import /tmp/pubkey.asc
+RUN rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n'
+RUN rpm -K /tmp/foo.rpm
+RUN rpm -K /tmp/foo.rpm | grep -E "(?:pgp|digests signatures) OK"
+RUN rpm -vK /tmp/foo.rpm
+RUN rpm -vK /tmp/foo.rpm | grep "RSA/SHA256 Signature, key ID 15bd80b3: OK"
+
+# Test with a repo
+RUN yum install -y createrepo yum-utils
+RUN rm -rf /etc/yum.repos.d/*.repo
+COPY keys/test.rpm.repo /etc/yum.repos.d/test.rpm.repo
+RUN createrepo /tmp
+RUN yum install -y foo
+

--- a/testdata/acceptance/rpm_centos9.dockerfile
+++ b/testdata/acceptance/rpm_centos9.dockerfile
@@ -1,9 +1,7 @@
-FROM dokken/centos-7 AS test_base
+FROM dokken/centos-stream-9 AS test_base
 ARG package
 RUN echo "${package}"
 COPY ${package} /tmp/foo.rpm
-
-
 
 # ---- signed test ----
 FROM test_base AS signed


### PR DESCRIPTION
I wanted to see how far back nfpm still works... seems like centos 8 is the last one.

Now, on a subsequent PR, I'll try to upgrade openpgp lib... I'm fairly certain at least centos8 will break.

We can then decide next steps.

