### PR TITLE
docs: improve deb fields var expansion example

### DIFF
--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -367,7 +367,7 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		packager        = "nope"
 		maintainerEmail = "nope@example.com"
 		homepage        = "https://nfpm.goreleaser.com"
-		vcsURL          = "https://github.com/goreleaser/nfpm.git"
+		vcsBrowser      = "https://github.com/goreleaser/nfpm"
 	)
 
 	t.Run("platform", func(t *testing.T) {
@@ -497,15 +497,15 @@ overrides:
 	})
 
 	t.Run("deb fields", func(t *testing.T) {
-		t.Setenv("CI_REPOSITORY_URL", vcsURL)
+		t.Setenv("CI_PROJECT_URL", vcsBrowser)
 		info, err := nfpm.Parse(strings.NewReader(`
 name: foo
 deb:
   fields:
-    Vcs-Git: ${CI_REPOSITORY_URL}
+    Vcs-Browser: ${CI_PROJECT_URL}
 `))
 		require.NoError(t, err)
-		require.Equal(t, vcsURL, info.Deb.Fields["Vcs-Git"])
+		require.Equal(t, vcsBrowser, info.Deb.Fields["Vcs-Browser"])
 	})
 }
 

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -404,7 +404,7 @@ deb:
     key_id: bc8acdd415bd80b3
 
   # Additional fields for the control file. Empty fields are ignored.
-  # This will expand any env vars you set in the field values, e.g. Vcs-Git: ${CI_REPOSITORY_URL}
+  # This will expand any env vars you set in the field values, e.g. Vcs-Browser: ${CI_PROJECT_URL}
   fields:
     Bugs: https://github.com/goreleaser/nfpm/issues
 


### PR DESCRIPTION
`$CI_REPOSITORY_URL` is not quite appropriate for `Vcs-Git`, use `$CI_PROJECT_URL` with `Vcs-Browser` instead.

- https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
- https://www.debian.org/doc/debian-policy/ch-controlfields.html#version-control-system-vcs-fields