### PR TITLE
feat: Add support for remote signing keys

### DIFF
--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -367,7 +366,7 @@ func TestSignatureError(t *testing.T) {
 func TestSignatureCallback(t *testing.T) {
 	info := exampleInfo()
 	info.APK.Signature.SignFn = func(r io.Reader) ([]byte, error) {
-		digest, err := ioutil.ReadAll(r)
+		digest, err := io.ReadAll(r)
 		if err != nil {
 			return nil, err
 		}

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -361,6 +362,33 @@ func TestSignatureError(t *testing.T) {
 	digest = sha1.New().Sum(nil) // nolint:gosec
 	err = createSignature(&signatureTarGz, info, digest)
 	require.True(t, errors.As(err, &expectedError))
+}
+
+func TestSignatureCallback(t *testing.T) {
+	info := exampleInfo()
+	info.APK.Signature.SignFn = func(r io.Reader) ([]byte, error) {
+		digest, err := ioutil.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+		return sign.RSASignSHA1Digest(digest, "../internal/sign/testdata/rsa.priv", "hunter2")
+	}
+	info.APK.Signature.KeyName = "testkey.rsa.pub"
+	err := nfpm.PrepareForPackager(info, "apk")
+	require.NoError(t, err)
+
+	digest := sha1.New().Sum(nil) // nolint:gosec
+
+	var signatureTarGz bytes.Buffer
+	tw := tar.NewWriter(&signatureTarGz)
+	require.NoError(t, createSignatureBuilder(digest, info)(tw))
+
+	signature := extractFromTar(t, signatureTarGz.Bytes(), ".SIGN.RSA.testkey.rsa.pub")
+	err = sign.RSAVerifySHA1Digest(digest, signature, "../internal/sign/testdata/rsa.pub")
+	require.NoError(t, err)
+
+	err = Default.Package(info, io.Discard)
+	require.NoError(t, err)
 }
 
 func TestDisableGlobbing(t *testing.T) {

--- a/nfpm.go
+++ b/nfpm.go
@@ -351,6 +351,13 @@ type PackageSignature struct {
 	KeyFile       string  `yaml:"key_file,omitempty" json:"key_file,omitempty" jsonschema:"title=key file,example=key.gpg"`
 	KeyID         *string `yaml:"key_id,omitempty" json:"key_id,omitempty" jsonschema:"title=key id,example=bc8acdd415bd80b3"`
 	KeyPassphrase string  `yaml:"-" json:"-"` // populated from environment variable
+	// SignFn, if set, will be called with the package-specific data to sign.
+	// For deb and rpm packages, data is the full package content.
+	// For apk packages, data is the SHA1 digest of control tgz.
+	//
+	// This allows for signing implementations other than using a local file
+	// (for example using a remote signer like KMS).
+	SignFn func(data io.Reader) ([]byte, error) `yaml:"-" json:"-"` // populated when used as a library
 }
 
 type RPMSignature struct {

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -126,6 +126,11 @@ func (*RPM) Package(info *nfpm.Info, w io.Writer) (err error) {
 			info.RPM.Signature.KeyID,
 		))
 	}
+	if signFn := info.RPM.Signature.SignFn; signFn != nil {
+		rpm.SetPGPSigner(func(data []byte) ([]byte, error) {
+			return signFn(bytes.NewReader(data))
+		})
+	}
 
 	if err = createFilesInsideRPM(info, rpm); err != nil {
 		return err

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -748,7 +747,7 @@ func TestRPMSignatureError(t *testing.T) {
 func TestRPMSignatureCallback(t *testing.T) {
 	info := exampleInfo()
 	info.RPM.Signature.SignFn = func(r io.Reader) ([]byte, error) {
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		if err != nil {
 			return nil, err
 		}

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/goreleaser/chglog"
 	"github.com/goreleaser/nfpm/v2"
 	"github.com/goreleaser/nfpm/v2/files"
+	"github.com/goreleaser/nfpm/v2/internal/sign"
 	"github.com/stretchr/testify/require"
 )
 
@@ -741,6 +743,32 @@ func TestRPMSignatureError(t *testing.T) {
 
 	var expectedError *nfpm.ErrSigningFailure
 	require.True(t, errors.As(err, &expectedError))
+}
+
+func TestRPMSignatureCallback(t *testing.T) {
+	info := exampleInfo()
+	info.RPM.Signature.SignFn = func(r io.Reader) ([]byte, error) {
+		data, err := ioutil.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+		return sign.PGPSignerWithKeyID("../internal/sign/testdata/privkey.asc", "hunter2", nil)(data)
+	}
+
+	pubkeyFileContent, err := os.ReadFile("../internal/sign/testdata/pubkey.gpg")
+	require.NoError(t, err)
+
+	keyring, err := openpgp.ReadKeyRing(bytes.NewReader(pubkeyFileContent))
+	require.NoError(t, err)
+	require.NotNil(t, keyring, "cannot verify sigs with an empty keyring")
+
+	var rpmBuffer bytes.Buffer
+	err = Default.Package(info, &rpmBuffer)
+	require.NoError(t, err)
+
+	_, sigs, err := rpmutils.Verify(bytes.NewReader(rpmBuffer.Bytes()), keyring)
+	require.NoError(t, err)
+	require.Len(t, sigs, 2)
 }
 
 func TestRPMGhostFiles(t *testing.T) {


### PR DESCRIPTION
When used as a library, `nfpm.PackageSignature.SignFn` can be set as an alternative to `KeyFile`. This allows arbitrary signing key implementations, like a remote signing server.

Updates https://github.com/tailscale/tailscale/issues/1882