### PR TITLE
feat(files): accept `doc`, `licen[cs]e`, and `readme` with non-rpm

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -37,13 +37,13 @@ const (
 	TypeConfigNoReplace = "config|noreplace"
 	// TypeGhost is the type of an RPM ghost file which is ignored by other packagers.
 	TypeRPMGhost = "ghost"
-	// TypeRPMDoc is the type of an RPM doc file which is ignored by other packagers.
+	// TypeRPMDoc is the type of an RPM doc file which is treated as a regular file by other packagers.
 	TypeRPMDoc = "doc"
-	// TypeRPMLicence is the type of an RPM licence file which is ignored by other packagers.
+	// TypeRPMLicence is the type of an RPM licence file which is treated as a regular file by other packagers.
 	TypeRPMLicence = "licence"
 	// TypeRPMLicense a different spelling of TypeRPMLicence.
 	TypeRPMLicense = "license"
-	// TypeRPMReadme is the type of an RPM readme file which is ignored by other packagers.
+	// TypeRPMReadme is the type of an RPM readme file which is treated as a regular file by other packagers.
 	TypeRPMReadme = "readme"
 	// TypeDebChangelog is the type of a Debian changelog archive file which is
 	// ignored by other packagers. This type should never be set for a content
@@ -321,10 +321,10 @@ func isRelevantForPackager(packager string, content *Content) bool {
 		return false
 	}
 
-	if packager != "rpm" &&
-		(content.Type == TypeRPMDoc || content.Type == TypeRPMLicence ||
-			content.Type == TypeRPMLicense || content.Type == TypeRPMReadme ||
-			content.Type == TypeRPMGhost) {
+	// Intentionally pass through TypeRPMDoc, TypeRPMLicen[cs]e, and TypeRPMReadme.
+	// It's convenient to install them without the extra type info with other packagers,
+	// instead of having to duplicate the entries in config without the type info.
+	if packager != "rpm" && content.Type == TypeRPMGhost {
 		return false
 	}
 


### PR DESCRIPTION
See commentary in code for elaboration.

This PR might be a bit incomplete: untested, no test coverage I think, and perhaps `RPM` should be dropped from the type names (with aliases for backwards compatibility) to make it clearer that files with them do get included with non-rpm packagers too.

Anyway, submitting here already in this form for discussion, before spending more time on it.

One example case is at https://github.com/aakso/ssh-inscribe/blob/7922b3e15f5fd9569c927f1464982c6f9e870f5b/.goreleaser.yaml#L69-L82. Note how the `LICENSE` and `README.md` entries need to be duplicated for deb and rpm; deb without the type info, rpm with it. It would get worse if there were more packager types enabled.