### PR TITLE
fix(rpm): conventionalfilename

### DIFF
--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -88,7 +88,13 @@ func (*RPM) ConventionalFileName(info *nfpm.Info) string {
 	info = setDefaults(info)
 
 	// name-version-release.architecture.rpm
-	return fmt.Sprintf("%s-%s.%s.rpm", info.Name, formatVersion(info), info.Arch)
+	return fmt.Sprintf(
+		"%s-%s-%s.%s.rpm",
+		info.Name,
+		formatVersion(info),
+		defaultTo(info.Release, "1"),
+		info.Arch,
+	)
 }
 
 // ConventionalExtension returns the file name conventionally used for RPM packages
@@ -266,7 +272,7 @@ func formatVersion(info *nfpm.Info) string {
 		version += "+" + info.VersionMetadata
 	}
 
-	return version + "-" + info.Release
+	return version
 }
 
 func defaultTo(in, def string) string {

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -118,7 +118,7 @@ func TestRPM(t *testing.T) {
 
 	version, err := rpm.Header.GetString(rpmutils.VERSION)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0-1", version)
+	require.Equal(t, "1.0.0", version)
 
 	release, err := rpm.Header.GetString(rpmutils.RELEASE)
 	require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestWithRPMTags(t *testing.T) {
 
 	version, err := rpm.Header.GetString(rpmutils.VERSION)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0-3", version)
+	require.Equal(t, "1.0.0", version)
 
 	release, err := rpm.Header.GetString(rpmutils.RELEASE)
 	require.NoError(t, err)
@@ -329,7 +329,7 @@ func TestRPMVersion(t *testing.T) {
 	info.Version = "1.0.0" //nolint:golint,goconst
 	meta, err := buildRPMMeta(info)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0-1", meta.Version)
+	require.Equal(t, "1.0.0", meta.Version)
 	require.Equal(t, "1", meta.Release)
 }
 
@@ -339,7 +339,7 @@ func TestRPMVersionWithRelease(t *testing.T) {
 	info.Release = "2"
 	meta, err := buildRPMMeta(info)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0-2", meta.Version)
+	require.Equal(t, "1.0.0", meta.Version)
 	require.Equal(t, "2", meta.Release)
 }
 
@@ -351,14 +351,14 @@ func TestRPMVersionWithPrerelease(t *testing.T) {
 	info.Prerelease = "rc1" // nolint:goconst
 	meta, err := buildRPMMeta(info)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0~rc1-1", meta.Version)
+	require.Equal(t, "1.0.0~rc1", meta.Version)
 	require.Equal(t, "1", meta.Release)
 
 	info.Version = "1.0.0~rc1"
 	info.Prerelease = ""
 	meta, err = buildRPMMeta(info)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0~rc1-1", meta.Version)
+	require.Equal(t, "1.0.0~rc1", meta.Version)
 	require.Equal(t, "1", meta.Release)
 }
 
@@ -371,7 +371,7 @@ func TestRPMVersionWithReleaseAndPrerelease(t *testing.T) {
 	info.Prerelease = "rc1"
 	meta, err := buildRPMMeta(info)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0~rc1-2", meta.Version)
+	require.Equal(t, "1.0.0~rc1", meta.Version)
 	require.Equal(t, "2", meta.Release)
 
 	info.Version = "1.0.0~rc1"
@@ -379,7 +379,7 @@ func TestRPMVersionWithReleaseAndPrerelease(t *testing.T) {
 	info.Prerelease = ""
 	meta, err = buildRPMMeta(info)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0~rc1-3", meta.Version)
+	require.Equal(t, "1.0.0~rc1", meta.Version)
 	require.Equal(t, "3", meta.Release)
 }
 
@@ -391,14 +391,16 @@ func TestRPMVersionWithVersionMetadata(t *testing.T) {
 	info.VersionMetadata = ""
 	meta, err := buildRPMMeta(info)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0+meta-1", meta.Version)
+	require.Equal(t, "1.0.0+meta", meta.Version)
+	require.Equal(t, "1", meta.Release)
 
 	info.Version = "1.0.0"
 	info.VersionMetadata = "meta"
 	info.Release = "10"
 	meta, err = buildRPMMeta(nfpm.WithDefaults(info))
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0+meta-10", meta.Version)
+	require.Equal(t, "1.0.0+meta", meta.Version)
+	require.Equal(t, "10", meta.Release)
 }
 
 func TestWithInvalidEpoch(t *testing.T) {

--- a/testdata/acceptance/rpm.dockerfile
+++ b/testdata/acceptance/rpm.dockerfile
@@ -123,7 +123,7 @@ RUN command -v zsh
 
 # ---- env-var-version test ----
 FROM min AS env-var-version
-ENV EXPECTVER="Version : 1.0.0~0.1.b1+git.abcdefgh-1" \
+ENV EXPECTVER="Version : 1.0.0~0.1.b1+git.abcdefgh" \
   EXPECTREL="Release : 1"
 RUN rpm -qpi /tmp/foo.rpm | sed -e 's/ \+/ /g' | grep "Version" > found.ver
 RUN rpm -qpi /tmp/foo.rpm | sed -e 's/ \+/ /g' | grep "Release" > found.rel


### PR DESCRIPTION
formatVersion is also used to set the version field of the RPM, which should not contain the release.

this fixes it, and the tests which were wrong.


closes #714 