### PR TITLE
fix(deb): blank line in package description

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -3,6 +3,7 @@ package deb
 
 import (
 	"archive/tar"
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"crypto/md5" // nolint:gas
@@ -762,8 +763,20 @@ func writeControl(w io.Writer, data controlData) error {
 			return strings.Trim(strings.Join(strs, ", "), " ")
 		},
 		"multiline": func(strs string) string {
-			ret := strings.ReplaceAll(strs, "\n", "\n ")
-			return strings.Trim(ret, " \n")
+			var b strings.Builder
+			s := bufio.NewScanner(strings.NewReader(strings.TrimSpace(strs)))
+			s.Scan()
+			b.Write(bytes.TrimSpace(s.Bytes()))
+			for s.Scan() {
+				b.WriteString("\n ")
+				l := bytes.TrimSpace(s.Bytes())
+				if len(l) == 0 {
+					b.WriteByte('.')
+				} else {
+					b.Write(l)
+				}
+			}
+			return b.String()
 		},
 		"nonEmpty": func(strs []string) []string {
 			var result []string

--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -523,7 +523,7 @@ func TestMultilineFields(t *testing.T) {
 		Info: nfpm.WithDefaults(&nfpm.Info{
 			Name:        "multiline",
 			Arch:        "riscv64",
-			Description: "This field is a\nmultiline field\nthat should work.",
+			Description: "This field is a\nmultiline field\n\nthat should work.",
 			Priority:    "extra",
 			Version:     "1.0.0",
 			Section:     "default",

--- a/deb/testdata/multiline.golden
+++ b/deb/testdata/multiline.golden
@@ -6,4 +6,5 @@ Architecture: riscv64
 Installed-Size: 0
 Description: This field is a
  multiline field
+ .
  that should work.


### PR DESCRIPTION
Blank lines in the deb's control file description are valid but need to be encoded with a space followed by a dot (`.`).

See https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-description.
> Those containing a single space followed by a single full stop character. These are rendered as blank lines. This is the only way to get a blank line.

I used nfpm to package one of my apps and it was broken as it did not add the dots onto the blank lines. This PR fixes that.