### PR TITLE
fix: Honor SOURCE_DATE_EPOCH for files

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -128,7 +128,7 @@ func (c *Content) WithFileInfoDefaults(umask fs.FileMode, mtime time.Time) *Cont
 	if (cc.Type == TypeDir || cc.Type == TypeImplicitDir) && cc.FileInfo.Mode == 0 {
 		cc.FileInfo.Mode = 0o755
 	}
-	if (cc.Type == TypeDir || cc.Type == TypeImplicitDir) && cc.FileInfo.MTime.IsZero() {
+	if cc.FileInfo.MTime.IsZero() {
 		cc.FileInfo.MTime = mtime
 	}
 

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -160,7 +160,7 @@ contents:
 	require.Equal(t, "files_test.go", f.Source)
 	require.Equal(t, "/b", f.Destination)
 	require.Equal(t, f.FileInfo.Mode, fi.Mode())
-	require.Equal(t, f.FileInfo.MTime, fi.ModTime())
+	require.Equal(t, f.FileInfo.MTime, mtime)
 }
 
 func TestFileInfo(t *testing.T) {


### PR DESCRIPTION
If set, SOURCE_DATE_EPOCH will be honored for all content entries.