### PR TITLE
feat(rpm): add support for verify scriptlet

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -202,6 +202,7 @@ func TestRPMSpecific(t *testing.T) {
 	testNames := []string{
 		"release",
 		"directories",
+		"verify",
 	}
 	for _, name := range testNames {
 		for _, arch := range formatArchs[format] {

--- a/nfpm.go
+++ b/nfpm.go
@@ -362,6 +362,7 @@ type RPM struct {
 type RPMScripts struct {
 	PreTrans  string `yaml:"pretrans,omitempty" json:"pretrans,omitempty" jsonschema:"title=pretrans script"`
 	PostTrans string `yaml:"posttrans,omitempty" json:"posttrans,omitempty" jsonschema:"title=posttrans script"`
+	Verify    string `yaml:"verify,omitempty" json:"verify,omitempty" jsonschema:"title=verify script"`
 }
 
 type PackageSignature struct {

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -342,6 +342,14 @@ func addScriptFiles(info *nfpm.Info, rpm *rpmpack.RPM) error {
 		rpm.AddPosttrans(string(data))
 	}
 
+	if info.RPM.Scripts.Verify != "" {
+		data, err := os.ReadFile(info.RPM.Scripts.Verify)
+		if err != nil {
+			return err
+		}
+		rpm.AddVerifyScript(string(data))
+	}
+
 	return nil
 }
 

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -82,6 +82,7 @@ func exampleInfo() *nfpm.Info {
 				Scripts: nfpm.RPMScripts{
 					PreTrans:  "../testdata/scripts/pretrans.sh",
 					PostTrans: "../testdata/scripts/posttrans.sh",
+					Verify:    "../testdata/scripts/verify.sh",
 				},
 			},
 		},
@@ -481,6 +482,13 @@ echo "Pretrans" > /dev/null
 
 echo "Posttrans" > /dev/null
 `, data, "Posttrans script does not match")
+
+	data, err = rpm.Header.GetString(rpmutils.VERIFYSCRIPT)
+	require.NoError(t, err)
+	require.Equal(t, `#!/bin/bash
+
+echo "Verify" > /dev/null
+`, data, "Verify script does not match")
 }
 
 func TestRPMFileDoesNotExist(t *testing.T) {

--- a/testdata/acceptance/core.complex.yaml
+++ b/testdata/acceptance/core.complex.yaml
@@ -72,6 +72,7 @@ rpm:
   scripts:
     pretrans: ./testdata/acceptance/scripts/pretrans.sh
     posttrans: ./testdata/acceptance/scripts/posttrans.sh
+    verify: ./testdata/acceptance/scripts/verify.sh
 apk:
   scripts:
     preupgrade: ./testdata/acceptance/scripts/preupgrade.sh

--- a/testdata/acceptance/rpm.dockerfile
+++ b/testdata/acceptance/rpm.dockerfile
@@ -220,3 +220,9 @@ RUN test ! -f /etc/bar/file
 RUN test -d /etc/foo
 RUN test ! -d /etc/bar
 RUN test ! -d /etc/baz
+
+# ---- verify test ----
+FROM min as verify
+RUN rpm -V foo
+RUN rm /tmp/postinstall-proof
+RUN ! rpm -V foo

--- a/testdata/acceptance/rpm.verify.yaml
+++ b/testdata/acceptance/rpm.verify.yaml
@@ -1,0 +1,20 @@
+name: "foo"
+arch: "${BUILD_ARCH}"
+platform: "linux"
+version: "v1.2.3"
+maintainer: "Foo Bar"
+release: "4"
+description: |
+  Foo bar
+    Multiple lines
+vendor: "foobar"
+homepage: "https://foobar.org"
+license: "MIT"
+contents:
+  - src: ./testdata/fake
+    dst: /etc/foo/file
+scripts:
+  postinstall: ./testdata/acceptance/scripts/postinstall.sh
+rpm:
+  scripts:
+    verify: ./testdata/acceptance/scripts/verify.sh

--- a/testdata/acceptance/scripts/verify.sh
+++ b/testdata/acceptance/scripts/verify.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+test -e /tmp/postinstall-proof

--- a/testdata/scripts/verify.sh
+++ b/testdata/scripts/verify.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Verify" > /dev/null

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -322,6 +322,8 @@ rpm:
     pretrans: ./scripts/pretrans.sh
     # The posttrans script runs after all RPM package transactions / stages.
     posttrans: ./scripts/posttrans.sh
+    # The verify script runs when verifying packages using `rpm -V`.
+    verify: ./scripts/verify.sh
 
   # The package group. This option is deprecated by most distros
   # but required by old distros like CentOS 5 / EL 5 and earlier.

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -719,6 +719,10 @@
 					"posttrans": {
 						"type": "string",
 						"title": "posttrans script"
+					},
+					"verify": {
+						"type": "string",
+						"title": "verify script"
 					}
 				},
 				"additionalProperties": false,


### PR DESCRIPTION
RPM allows users to add custom verify scriptlets that are run by `rpm -V` in addition to the normal checksum validation. This is useful when there are additional factors that indicate a valid installation, like, for example, checking for valid contents of configuration files.