### PR TITLE
feat: Added "excludes" option to prevent packing unnecessary files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: sigstore/cosign-installer@v3.5.0
-      - uses: anchore/sbom-action/download-syft@v0.15.10
+      - uses: anchore/sbom-action/download-syft@v0.15.11
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: cachix/install-nix-action@v26

--- a/files/files.go
+++ b/files/files.go
@@ -60,6 +60,7 @@ type Content struct {
 	Packager    string           `yaml:"packager,omitempty" json:"packager,omitempty"`
 	FileInfo    *ContentFileInfo `yaml:"file_info,omitempty" json:"file_info,omitempty"`
 	Expand      bool             `yaml:"expand,omitempty" json:"expand,omitempty"`
+	Excludes    []string         `yaml:"excludes,omitempty" json:"excludes,omitempty"`
 }
 
 type ContentFileInfo struct {
@@ -470,6 +471,15 @@ func addTree(
 		}
 
 		destination := filepath.Join(tree.Destination, relPath)
+
+		if tree.Excludes != nil {
+			// Check if src matches any of the exclude patterns
+			for _, exclude := range tree.Excludes {
+				if strings.Contains(destination, exclude) {
+					return nil
+				}
+			}
+		}
 
 		c := &Content{
 			FileInfo: &ContentFileInfo{},

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -931,6 +931,57 @@ func TestTreeMode(t *testing.T) {
 	}
 }
 
+func TestExcludesTree(t *testing.T) {
+	results, err := files.PrepareForPackager(
+		files.Contents{
+			{
+				Source:      filepath.Join("testdata", "tree"),
+				Destination: "/base",
+				Type:        files.TypeTree,
+				Excludes:    []string{"/base/files/b"},
+			},
+		},
+		0,
+		"",
+		false,
+		mtime,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, files.Contents{
+		{
+			Source:      "",
+			Destination: "/base/",
+			Type:        files.TypeDir,
+		},
+		{
+			Source:      "",
+			Destination: "/base/files/",
+			Type:        files.TypeDir,
+		},
+		{
+			Source:      filepath.Join("testdata", "tree", "files", "a"),
+			Destination: "/base/files/a",
+			Type:        files.TypeFile,
+		},
+		{
+			Source:      "",
+			Destination: "/base/symlinks/",
+			Type:        files.TypeDir,
+		},
+		{
+			Source:      "/etc/foo",
+			Destination: "/base/symlinks/link1",
+			Type:        files.TypeSymlink,
+		},
+		{
+			Source:      "../files/a",
+			Destination: "/base/symlinks/link2",
+			Type:        files.TypeSymlink,
+		},
+	}, withoutFileInfo(results))
+}
+
 func withoutFileInfo(contents files.Contents) files.Contents {
 	filtered := make(files.Contents, 0, len(contents))
 

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -103,4 +103,12 @@ func TestGlob(t *testing.T) {
 		require.Len(t, files, 1)
 		require.Equal(t, "/foo/bar/dest.dat", files["testdata/dir_a/dir_b/test_b.txt"])
 	})
+
+	t.Run("simple excludes", func(t *testing.T) {
+		var excludes []string = []string{"/foo/bar/dir_c/*"}
+		files, err := GlobExcludes("./testdata/dir_a/dir_*/*", "/foo/bar", excludes)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		require.Equal(t, "/foo/bar/dir_b/test_b.txt", files["testdata/dir_a/dir_b/test_b.txt"])
+	})
 }

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -184,7 +184,7 @@ contents:
   - src: path/to/local/*.1.gz
     dst: /usr/share/man/man1/
 
-  # Simple symlink at /usr/bin/foo which points to /sbin/foo, which is
+# Simple symlink at /usr/bin/foo which points to /sbin/foo, which is
   # the same behaviour as `ln -s /sbin/foo /usr/bin/foo`.
   #
   # This also means that both "src" and "dst" are paths inside the package (or
@@ -265,6 +265,22 @@ contents:
   - dst: /usr/local/bin/${NAME}
     src: "${NAME}"
     expand: true
+
+  # This replicates the directory structure from some/directory to /etc.
+  # By specifying "excludes", directories under /etc/ are not duplicated.
+  # If "excludes -/etc/dir_c" is set, then some/directory/dir_c will not be replicated.
+  - src: some/directory/
+    dst: /etc
+    type: tree
+    excludes:
+      - /etc/dir_c
+
+  # Select files in glob.
+  # Set "excludes" to exclude files from being copied to dst
+  - src: path/to/local/*.1.gz
+    dst: /usr/share/man/man1/
+    excludes:
+      - /usr/share/man/man1/*a.1.gz
 
 # Umask to be used on files without explicit mode set.
 #

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -365,6 +365,12 @@
 					},
 					"expand": {
 						"type": "boolean"
+					},
+					"excludes": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
 					}
 				},
 				"additionalProperties": false,


### PR DESCRIPTION
For the type:tree option or when using glob settings, an excludes setting has been added.
If the excludes setting is specified, the target files will not be copied to the dst directory.

for examples:

```
contents:
  - src: ./service
    dst: /service
    type: tree
    excludes:
      - /service/folder
      - /service/etc
```