### PR TITLE
test: latest debian

### DIFF
--- a/testdata/acceptance/deb.dockerfile
+++ b/testdata/acceptance/deb.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11 AS test_base
+FROM debian AS test_base
 ARG package
 RUN echo "${package}"
 COPY ${package} /tmp/foo.deb


### PR DESCRIPTION
this fixes dpkg-sig tests, but breaks debsig


I have no idea why... anyone?