### PR TITLE
feat: env var substitution in description

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -231,6 +231,7 @@ func (c *Config) expandEnvVars() {
 	c.Info.Homepage = os.Expand(c.Info.Homepage, c.envMappingFunc)
 	c.Info.Maintainer = os.Expand(c.Info.Maintainer, c.envMappingFunc)
 	c.Info.Vendor = os.Expand(c.Info.Vendor, c.envMappingFunc)
+	c.Info.Description = os.Expand(c.Info.Description, c.envMappingFunc)
 
 	// Package signing related fields
 	c.Info.Deb.Signature.KeyFile = os.Expand(c.Deb.Signature.KeyFile, c.envMappingFunc)

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -313,11 +313,13 @@ func TestParseFile(t *testing.T) {
 	t.Setenv("RPM_KEY_FILE", "my/rpm/key/file")
 	t.Setenv("TEST_RELEASE_ENV_VAR", "1234")
 	t.Setenv("TEST_PRERELEASE_ENV_VAR", "beta1")
+	t.Setenv("TEST_DESCRIPTION_ENV_VAR", "description")
 	config, err := parseAndValidate("./testdata/env-fields.yaml")
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("v%s", os.Getenv("GOROOT")), config.Version)
 	require.Equal(t, "1234", config.Release)
 	require.Equal(t, "beta1", config.Prerelease)
+	require.Equal(t, "My description", config.Description)
 	require.Equal(t, "my/rpm/key/file", config.RPM.Signature.KeyFile)
 	require.Equal(t, "hard/coded/file", config.Deb.Signature.KeyFile)
 	require.Equal(t, "", config.APK.Signature.KeyFile)
@@ -381,6 +383,7 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		maintainerEmail = "nope@example.com"
 		homepage        = "https://nfpm.goreleaser.com"
 		vcsBrowser      = "https://github.com/goreleaser/nfpm"
+		description     = "barfoo"
 	)
 
 	t.Run("platform", func(t *testing.T) {
@@ -438,6 +441,13 @@ maintainer: '"$GIT_COMMITTER_NAME" <$GIT_COMMITTER_EMAIL>'
 		info, err := nfpm.Parse(strings.NewReader("name: foo\nhomepage: $CI_PROJECT_URL"))
 		require.NoError(t, err)
 		require.Equal(t, homepage, info.Homepage)
+	})
+
+	t.Run("description", func(t *testing.T) {
+		t.Setenv("DESCRIPTION", description)
+		info, err := nfpm.Parse(strings.NewReader("name: foo\ndescription: $DESCRIPTION"))
+		require.NoError(t, err)
+		require.Equal(t, description, info.Description)
 	})
 
 	t.Run("global passphrase", func(t *testing.T) {

--- a/testdata/env-fields.yaml
+++ b/testdata/env-fields.yaml
@@ -4,6 +4,7 @@ arch: "amd64"
 version: "v$GOROOT"
 release: ${TEST_RELEASE_ENV_VAR}
 prerelease: ${TEST_PRERELEASE_ENV_VAR}
+description: My ${TEST_DESCRIPTION_ENV_VAR}
 contents:
 - src: ./testdata/whatever.conf
   dst: /etc/foo/regular.conf

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -83,6 +83,7 @@ priority: extra
 maintainer: Carlos Alexandro Becker <root@carlosbecker.com>
 
 # Description.
+# This will expand any env var you set in the field, e.g. description: ${DESCRIPTION}
 # Defaults to `no description given`.
 # Most packagers call for a one-line synopsis of the package. Some (like deb)
 # also call for a multi-line description starting on the second line.


### PR DESCRIPTION
Hello!

I noticed you support the environment variable interpolation in many fields in a configuration but not in the description.
This merge request fills this gap.

I added the unit tests for the new code and altered the docs. Please notify me if I missed something or if my code doesn't fit your coding guidelines - I will fix it.

Regards!