### PR TITLE
fix: undefined variable 'staging-pkgs'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
 
         # nix develop .#docs
         devShells.docs = pkgs.mkShell {
-          packages = with pkgs; with staging-pkgs.python311Packages; [
+          packages = with pkgs; with pkgs.python311Packages; [
             (pkgs.writeScriptBin "ci-docs" "task docs:test")
             go-task
             htmltest


### PR DESCRIPTION
This commit fixes the undefined staging-pkgs like in the GitHub Actions runs:
[example](https://github.com/goreleaser/nfpm/actions/runs/10854480085/job/30124997498#step:4:87)