### PR TITLE
chore(deps): remove github.com/xi2/xz

### DIFF
--- a/deb/deb_test.go
+++ b/deb/deb_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/goreleaser/nfpm/v2/internal/sign"
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
-	"github.com/xi2/xz"
+	"github.com/ulikunitz/xz"
 )
 
 // nolint: gochecknoglobals
@@ -1325,7 +1325,7 @@ func inflate(tb testing.TB, nameOrType string, data []byte) []byte {
 		inflateReadCloser, err = gzip.NewReader(dataReader)
 		require.NoError(tb, err)
 	case "xz":
-		r, err := xz.NewReader(dataReader, 0)
+		r, err := xz.NewReader(dataReader)
 		require.NoError(tb, err)
 		inflateReadCloser = io.NopCloser(r)
 	case "zst":

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	github.com/ulikunitz/xz v0.5.12
-	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -68,6 +67,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	gitlab.com/digitalxero/go-conventional-commit v1.0.7 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect


### PR DESCRIPTION
This PR removes the direct dependency on `github.com/xi2/xz` because the same functionality exists in the already present `github.com/ulikunitz/xz`.

Compare:
- [xi2/xz.NewReader](https://github.com/xi2/xz/blob/48954b6210f8d154cb5f8484d3a3e1f83489309e/reader.go#L67)
- [ulikunitz/xz.NewReader](https://pkg.go.dev/github.com/ulikunitz/xz#NewReader)
