### PR TITLE
ci: publish AUR from sources

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,6 +95,10 @@ archives:
       - completions/*
       - manpages/*
 
+source:
+  enabled: true
+  name_template: '{{ .ProjectName }}_{{ .Version }}_source'
+
 brews:
   - repository:
       owner: goreleaser
@@ -220,6 +224,46 @@ aurs:
       install -Dm644 "./completions/nfpm.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/nfpm.fish"
       # man pages
       install -Dm644 "./manpages/nfpm.1.gz" "${pkgdir}/usr/share/man/man1/nfpm.1.gz"
+
+aur_sources:
+  - homepage: https://nfpm.goreleaser.com
+    description: nFPM is a simple, 0-dependencies, deb, rpm and apk packager.
+    maintainers:
+      - "Fernandez Ludovic <lfernandez dot dev at gmail dot com>"
+      - "Carlos Alexandro Becker <carlos at becker dot software>"
+    license: MIT
+    private_key: "{{ .Env.AUR_KEY }}"
+    git_url: "ssh://aur@aur.archlinux.org/nfpm.git"
+    build: |-
+      cd "${pkgname}-${pkgver}"
+
+      export CGO_CPPFLAGS="${CPPFLAGS}"
+      export CGO_CFLAGS="${CFLAGS}"
+      export CGO_CXXFLAGS="${CXXFLAGS}"
+      export CGO_LDFLAGS="${LDFLAGS}"
+      export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+      go build -ldflags="-w -s -buildid='' -linkmode=external -X main.version=v${pkgver}" ./cmd/nfpm
+
+      ls -alF
+      chmod +x "./${pkgname}"
+    package: |-
+
+      cd "${pkgname}-${pkgver}"
+      ls -alF
+
+      # Bin
+      install -Dsm755 "./${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+
+      # License
+      install -Dm644 "./LICENSE.md" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
+      # Completions
+      mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
+      mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
+      mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
+      ./${pkgname} completion bash > "${pkgdir}/usr/share/bash-completion/completions/${pkgname}"
+      ./${pkgname} completion zsh > "${pkgdir}/usr/share/zsh/site-functions/_${pkgname}"
+      ./${pkgname} completion fish > "${pkgdir}/usr/share/fish/vendor_completions.d/${pkgname}.fish"
 
 furies:
   - account: goreleaser


### PR DESCRIPTION
- adds a source package
- adds the AUR from sources

Based on the current [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=nfpm)