### PR TITLE
feat: Add BuildHost option to RPM packages

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -377,6 +377,7 @@ type ArchLinuxScripts struct {
 // RPM is custom configs that are only available on RPM packages.
 type RPM struct {
 	Arch        string       `yaml:"arch,omitempty" json:"arch,omitempty" jsonschema:"title=architecture in rpm nomenclature"`
+	BuildHost   string       `yaml:"buildhost,omitempty" json:"buildhost,omitempty" jsonschema:"title=host name of the build environment, default=os.Hostname()"`
 	Scripts     RPMScripts   `yaml:"scripts,omitempty" json:"scripts,omitempty" jsonschema:"title=rpm-specific scripts"`
 	Group       string       `yaml:"group,omitempty" json:"group,omitempty" jsonschema:"title=package group,example=Unspecified"`
 	Summary     string       `yaml:"summary,omitempty" json:"summary,omitempty" jsonschema:"title=package summary"`

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -235,9 +235,12 @@ func buildRPMMeta(info *nfpm.Info) (*rpmpack.RPMMetaData, error) {
 		return nil, err
 	}
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
+	hostname := info.RPM.BuildHost
+	if hostname == "" {
+		hostname, err = os.Hostname()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &rpmpack.RPMMetaData{

--- a/rpm/rpm_test.go
+++ b/rpm/rpm_test.go
@@ -80,8 +80,9 @@ func exampleInfo() *nfpm.Info {
 				PostRemove:  "../testdata/scripts/postremove.sh",
 			},
 			RPM: nfpm.RPM{
-				Group:    "foo",
-				Prefixes: []string{"/opt"},
+				Group:     "foo",
+				BuildHost: "barhost",
+				Prefixes:  []string{"/opt"},
 				Scripts: nfpm.RPMScripts{
 					PreTrans:  "../testdata/scripts/pretrans.sh",
 					PostTrans: "../testdata/scripts/posttrans.sh",
@@ -138,6 +139,10 @@ func TestRPM(t *testing.T) {
 	group, err := rpm.Header.GetString(rpmutils.GROUP)
 	require.NoError(t, err)
 	require.Equal(t, "foo", group)
+
+	buildhost, err := rpm.Header.GetString(rpmutils.BUILDHOST)
+	require.NoError(t, err)
+	require.Equal(t, "barhost", buildhost)
 
 	summary, err := rpm.Header.GetString(rpmutils.SUMMARY)
 	require.NoError(t, err)

--- a/www/docs/configuration.md
+++ b/www/docs/configuration.md
@@ -351,6 +351,10 @@ rpm:
   # This will expand any env var you set in the field, e.g. packager: ${PACKAGER}
   packager: GoReleaser <staff@goreleaser.com>
 
+  # The hostname of the machine the rpm was built with.  If ommited os.Hostname()
+  # will be used.
+  buildhost: buildserver1
+
   # Compression algorithm (gzip (default), zstd, lzma or xz).
   compression: zstd
 

--- a/www/docs/static/schema.json
+++ b/www/docs/static/schema.json
@@ -1,855 +1,859 @@
 {
-		"$schema": "https://json-schema.org/draft/2020-12/schema",
-		"$id": "https://github.com/goreleaser/nfpm/v2/config",
-		"$ref": "#/$defs/Config",
-		"$defs": {
-			"APK": {
-				"properties": {
-					"arch": {
-						"type": "string",
-						"title": "architecture in apk nomenclature"
-					},
-					"signature": {
-						"$ref": "#/$defs/APKSignature",
-						"title": "apk signature"
-					},
-					"scripts": {
-						"$ref": "#/$defs/APKScripts",
-						"title": "apk scripts"
-					}
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://github.com/goreleaser/nfpm/v2/config",
+	"$ref": "#/$defs/Config",
+	"$defs": {
+		"APK": {
+			"properties": {
+				"arch": {
+					"type": "string",
+					"title": "architecture in apk nomenclature"
 				},
-				"additionalProperties": false,
-				"type": "object"
+				"signature": {
+					"$ref": "#/$defs/APKSignature",
+					"title": "apk signature"
+				},
+				"scripts": {
+					"$ref": "#/$defs/APKScripts",
+					"title": "apk scripts"
+				}
 			},
-			"APKScripts": {
-				"properties": {
-					"preupgrade": {
-						"type": "string",
-						"title": "pre upgrade script"
-					},
-					"postupgrade": {
-						"type": "string",
-						"title": "post upgrade script"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"APKSignature": {
-				"properties": {
-					"key_file": {
-						"type": "string",
-						"title": "key file",
-						"examples": [
-							"key.gpg"
-						]
-					},
-					"key_id": {
-						"type": "string",
-						"title": "key id",
-						"examples": [
-							"bc8acdd415bd80b3"
-						]
-					},
-					"key_name": {
-						"type": "string",
-						"title": "key name",
-						"default": "maintainer_email.rsa.pub",
-						"examples": [
-							"origin"
-						]
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"ArchLinux": {
-				"properties": {
-					"pkgbase": {
-						"type": "string",
-						"title": "explicitly specify the name used to refer to a split package"
-					},
-					"arch": {
-						"type": "string",
-						"title": "architecture in archlinux nomenclature"
-					},
-					"packager": {
-						"type": "string",
-						"title": "organization that packaged the software"
-					},
-					"scripts": {
-						"$ref": "#/$defs/ArchLinuxScripts",
-						"title": "archlinux-specific scripts"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"ArchLinuxScripts": {
-				"properties": {
-					"preupgrade": {
-						"type": "string",
-						"title": "preupgrade script"
-					},
-					"postupgrade": {
-						"type": "string",
-						"title": "postupgrade script"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"Config": {
-				"properties": {
-					"replaces": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "replaces directive"
-					},
-					"provides": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "provides directive"
-					},
-					"depends": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "depends directive"
-					},
-					"recommends": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "recommends directive"
-					},
-					"suggests": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "suggests directive"
-					},
-					"conflicts": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "conflicts directive"
-					},
-					"contents": {
-						"$ref": "#/$defs/Contents",
-						"title": "files to add to the package"
-					},
-					"umask": {
-						"type": "integer",
-						"title": "umask for file contents",
-						"examples": [
-							112
-						]
-					},
-					"scripts": {
-						"$ref": "#/$defs/Scripts",
-						"title": "scripts to execute"
-					},
-					"rpm": {
-						"$ref": "#/$defs/RPM",
-						"title": "rpm-specific settings"
-					},
-					"deb": {
-						"$ref": "#/$defs/Deb",
-						"title": "deb-specific settings"
-					},
-					"apk": {
-						"$ref": "#/$defs/APK",
-						"title": "apk-specific settings"
-					},
-					"archlinux": {
-						"$ref": "#/$defs/ArchLinux",
-						"title": "archlinux-specific settings"
-					},
-					"ipk": {
-						"$ref": "#/$defs/IPK",
-						"title": "ipk-specific settings"
-					},
-					"name": {
-						"type": "string",
-						"title": "package name"
-					},
-					"arch": {
-						"type": "string",
-						"title": "target architecture",
-						"examples": [
-							"amd64"
-						]
-					},
-					"platform": {
-						"type": "string",
-						"title": "target platform",
-						"default": "linux",
-						"examples": [
-							"linux"
-						]
-					},
-					"epoch": {
-						"type": "string",
-						"title": "version epoch",
-						"default": "extracted from version",
-						"examples": [
-							"2"
-						]
-					},
-					"version": {
-						"type": "string",
-						"title": "version",
-						"examples": [
-							"v1.0.2",
-							"2.0.1"
-						]
-					},
-					"version_schema": {
-						"type": "string",
-						"enum": [
-							"semver",
-							"none"
-						],
-						"title": "version schema",
-						"default": "semver"
-					},
-					"release": {
-						"type": "string",
-						"title": "version release",
-						"examples": [
-							"1"
-						]
-					},
-					"prerelease": {
-						"type": "string",
-						"title": "version prerelease",
-						"default": "extracted from version"
-					},
-					"version_metadata": {
-						"type": "string",
-						"title": "version metadata",
-						"examples": [
-							"git"
-						]
-					},
-					"section": {
-						"type": "string",
-						"title": "package section",
-						"examples": [
-							"default"
-						]
-					},
-					"priority": {
-						"type": "string",
-						"title": "package priority",
-						"examples": [
-							"extra"
-						]
-					},
-					"maintainer": {
-						"type": "string",
-						"title": "package maintainer",
-						"examples": [
-							"me@example.com"
-						]
-					},
-					"description": {
-						"type": "string",
-						"title": "package description"
-					},
-					"vendor": {
-						"type": "string",
-						"title": "package vendor",
-						"examples": [
-							"MyCorp"
-						]
-					},
-					"homepage": {
-						"type": "string",
-						"title": "package homepage",
-						"examples": [
-							"https://example.com"
-						]
-					},
-					"license": {
-						"type": "string",
-						"title": "package license",
-						"examples": [
-							"MIT"
-						]
-					},
-					"changelog": {
-						"type": "string",
-						"title": "package changelog",
-						"description": "see https://github.com/goreleaser/chglog for more details",
-						"examples": [
-							"changelog.yaml"
-						]
-					},
-					"disable_globbing": {
-						"type": "boolean",
-						"title": "whether to disable file globbing",
-						"default": false
-					},
-					"mtime": {
-						"type": "string",
-						"format": "date-time",
-						"title": "time to set into the files generated by nFPM"
-					},
-					"overrides": {
-						"additionalProperties": {
-							"$ref": "#/$defs/Overridables"
-						},
-						"type": "object",
-						"title": "overrides",
-						"description": "override some fields when packaging with a specific packager"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object",
-				"required": [
-					"name",
-					"arch",
-					"version"
-				]
-			},
-			"Content": {
-				"properties": {
-					"src": {
-						"type": "string"
-					},
-					"dst": {
-						"type": "string"
-					},
-					"type": {
-						"type": "string",
-						"enum": [
-							"symlink",
-							"ghost",
-							"config",
-							"config|noreplace",
-							"dir",
-							"tree",
-							""
-						],
-						"default": ""
-					},
-					"packager": {
-						"type": "string"
-					},
-					"file_info": {
-						"$ref": "#/$defs/ContentFileInfo"
-					},
-					"expand": {
-						"type": "boolean"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object",
-				"required": [
-					"dst"
-				]
-			},
-			"ContentFileInfo": {
-				"properties": {
-					"owner": {
-						"type": "string"
-					},
-					"group": {
-						"type": "string"
-					},
-					"mode": {
-						"type": "integer"
-					},
-					"mtime": {
-						"type": "string",
-						"format": "date-time"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"Contents": {
-				"items": {
-					"$ref": "#/$defs/Content"
-				},
-				"type": "array"
-			},
-			"Deb": {
-				"properties": {
-					"arch": {
-						"type": "string",
-						"title": "architecture in deb nomenclature"
-					},
-					"scripts": {
-						"$ref": "#/$defs/DebScripts",
-						"title": "scripts"
-					},
-					"triggers": {
-						"$ref": "#/$defs/DebTriggers",
-						"title": "triggers"
-					},
-					"breaks": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"title": "breaks"
-					},
-					"signature": {
-						"$ref": "#/$defs/DebSignature",
-						"title": "signature"
-					},
-					"compression": {
-						"type": "string",
-						"enum": [
-							"gzip",
-							"xz",
-							"none"
-						],
-						"title": "compression algorithm to be used",
-						"default": "gzip"
-					},
-					"fields": {
-						"additionalProperties": {
-							"type": "string"
-						},
-						"type": "object",
-						"title": "fields"
-					},
-					"predepends": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "predepends directive"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"DebScripts": {
-				"properties": {
-					"rules": {
-						"type": "string",
-						"title": "rules"
-					},
-					"templates": {
-						"type": "string",
-						"title": "templates"
-					},
-					"config": {
-						"type": "string",
-						"title": "config"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"DebSignature": {
-				"properties": {
-					"key_file": {
-						"type": "string",
-						"title": "key file",
-						"examples": [
-							"key.gpg"
-						]
-					},
-					"key_id": {
-						"type": "string",
-						"title": "key id",
-						"examples": [
-							"bc8acdd415bd80b3"
-						]
-					},
-					"method": {
-						"type": "string",
-						"enum": [
-							"debsign"
-						],
-						"title": "method role",
-						"default": "debsign"
-					},
-					"type": {
-						"type": "string",
-						"enum": [
-							"origin",
-							"maint",
-							"archive"
-						],
-						"title": "signer role",
-						"default": "origin"
-					},
-					"signer": {
-						"type": "string",
-						"title": "signer"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"DebTriggers": {
-				"properties": {
-					"interest": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"title": "interest"
-					},
-					"interest_await": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"title": "interest await"
-					},
-					"interest_noawait": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"title": "interest noawait"
-					},
-					"activate": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"title": "activate"
-					},
-					"activate_await": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"title": "activate await"
-					},
-					"activate_noawait": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"title": "activate noawait"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"IPK": {
-				"properties": {
-					"abi_version": {
-						"type": "string",
-						"title": "abi version"
-					},
-					"alternatives": {
-						"items": {
-							"$ref": "#/$defs/IPKAlternative"
-						},
-						"type": "array",
-						"title": "alternatives"
-					},
-					"arch": {
-						"type": "string",
-						"title": "architecture in deb nomenclature"
-					},
-					"auto_installed": {
-						"type": "boolean",
-						"title": "auto installed",
-						"default": false
-					},
-					"essential": {
-						"type": "boolean",
-						"title": "whether package is essential",
-						"default": false
-					},
-					"fields": {
-						"additionalProperties": {
-							"type": "string"
-						},
-						"type": "object",
-						"title": "fields"
-					},
-					"predepends": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "predepends directive"
-					},
-					"tags": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"title": "tags"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"IPKAlternative": {
-				"properties": {
-					"priority": {
-						"type": "integer",
-						"title": "priority"
-					},
-					"target": {
-						"type": "string",
-						"title": "target"
-					},
-					"link_name": {
-						"type": "string",
-						"title": "link name"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"Overridables": {
-				"properties": {
-					"replaces": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "replaces directive"
-					},
-					"provides": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "provides directive"
-					},
-					"depends": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "depends directive"
-					},
-					"recommends": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "recommends directive"
-					},
-					"suggests": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "suggests directive"
-					},
-					"conflicts": {
-						"items": {
-							"type": "string",
-							"examples": [
-								"nfpm"
-							]
-						},
-						"type": "array",
-						"title": "conflicts directive"
-					},
-					"contents": {
-						"$ref": "#/$defs/Contents",
-						"title": "files to add to the package"
-					},
-					"umask": {
-						"type": "integer",
-						"title": "umask for file contents",
-						"examples": [
-							112
-						]
-					},
-					"scripts": {
-						"$ref": "#/$defs/Scripts",
-						"title": "scripts to execute"
-					},
-					"rpm": {
-						"$ref": "#/$defs/RPM",
-						"title": "rpm-specific settings"
-					},
-					"deb": {
-						"$ref": "#/$defs/Deb",
-						"title": "deb-specific settings"
-					},
-					"apk": {
-						"$ref": "#/$defs/APK",
-						"title": "apk-specific settings"
-					},
-					"archlinux": {
-						"$ref": "#/$defs/ArchLinux",
-						"title": "archlinux-specific settings"
-					},
-					"ipk": {
-						"$ref": "#/$defs/IPK",
-						"title": "ipk-specific settings"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"RPM": {
-				"properties": {
-					"arch": {
-						"type": "string",
-						"title": "architecture in rpm nomenclature"
-					},
-					"scripts": {
-						"$ref": "#/$defs/RPMScripts",
-						"title": "rpm-specific scripts"
-					},
-					"group": {
-						"type": "string",
-						"title": "package group",
-						"examples": [
-							"Unspecified"
-						]
-					},
-					"summary": {
-						"type": "string",
-						"title": "package summary"
-					},
-					"compression": {
-						"type": "string",
-						"enum": [
-							"gzip",
-							"lzma",
-							"xz"
-						],
-						"title": "compression algorithm to be used",
-						"default": "gzip:-1"
-					},
-					"signature": {
-						"$ref": "#/$defs/RPMSignature",
-						"title": "rpm signature"
-					},
-					"packager": {
-						"type": "string",
-						"title": "organization that actually packaged the software"
-					},
-					"prefixes": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array",
-						"title": "Prefixes for relocatable packages"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"RPMScripts": {
-				"properties": {
-					"pretrans": {
-						"type": "string",
-						"title": "pretrans script"
-					},
-					"posttrans": {
-						"type": "string",
-						"title": "posttrans script"
-					},
-					"verify": {
-						"type": "string",
-						"title": "verify script"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"RPMSignature": {
-				"properties": {
-					"key_file": {
-						"type": "string",
-						"title": "key file",
-						"examples": [
-							"key.gpg"
-						]
-					},
-					"key_id": {
-						"type": "string",
-						"title": "key id",
-						"examples": [
-							"bc8acdd415bd80b3"
-						]
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			},
-			"Scripts": {
-				"properties": {
-					"preinstall": {
-						"type": "string",
-						"title": "pre install"
-					},
-					"postinstall": {
-						"type": "string",
-						"title": "post install"
-					},
-					"preremove": {
-						"type": "string",
-						"title": "pre remove"
-					},
-					"postremove": {
-						"type": "string",
-						"title": "post remove"
-					}
-				},
-				"additionalProperties": false,
-				"type": "object"
-			}
+			"additionalProperties": false,
+			"type": "object"
 		},
-		"description": "nFPM configuration definition file"
-	}
+		"APKScripts": {
+			"properties": {
+				"preupgrade": {
+					"type": "string",
+					"title": "pre upgrade script"
+				},
+				"postupgrade": {
+					"type": "string",
+					"title": "post upgrade script"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"APKSignature": {
+			"properties": {
+				"key_file": {
+					"type": "string",
+					"title": "key file",
+					"examples": [
+						"key.gpg"
+					]
+				},
+				"key_id": {
+					"type": "string",
+					"title": "key id",
+					"examples": [
+						"bc8acdd415bd80b3"
+					]
+				},
+				"key_name": {
+					"type": "string",
+					"title": "key name",
+					"default": "maintainer_email.rsa.pub",
+					"examples": [
+						"origin"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"ArchLinux": {
+			"properties": {
+				"pkgbase": {
+					"type": "string",
+					"title": "explicitly specify the name used to refer to a split package"
+				},
+				"arch": {
+					"type": "string",
+					"title": "architecture in archlinux nomenclature"
+				},
+				"packager": {
+					"type": "string",
+					"title": "organization that packaged the software"
+				},
+				"scripts": {
+					"$ref": "#/$defs/ArchLinuxScripts",
+					"title": "archlinux-specific scripts"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"ArchLinuxScripts": {
+			"properties": {
+				"preupgrade": {
+					"type": "string",
+					"title": "preupgrade script"
+				},
+				"postupgrade": {
+					"type": "string",
+					"title": "postupgrade script"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"Config": {
+			"properties": {
+				"replaces": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "replaces directive"
+				},
+				"provides": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "provides directive"
+				},
+				"depends": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "depends directive"
+				},
+				"recommends": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "recommends directive"
+				},
+				"suggests": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "suggests directive"
+				},
+				"conflicts": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "conflicts directive"
+				},
+				"contents": {
+					"$ref": "#/$defs/Contents",
+					"title": "files to add to the package"
+				},
+				"umask": {
+					"type": "integer",
+					"title": "umask for file contents",
+					"examples": [
+						112
+					]
+				},
+				"scripts": {
+					"$ref": "#/$defs/Scripts",
+					"title": "scripts to execute"
+				},
+				"rpm": {
+					"$ref": "#/$defs/RPM",
+					"title": "rpm-specific settings"
+				},
+				"deb": {
+					"$ref": "#/$defs/Deb",
+					"title": "deb-specific settings"
+				},
+				"apk": {
+					"$ref": "#/$defs/APK",
+					"title": "apk-specific settings"
+				},
+				"archlinux": {
+					"$ref": "#/$defs/ArchLinux",
+					"title": "archlinux-specific settings"
+				},
+				"ipk": {
+					"$ref": "#/$defs/IPK",
+					"title": "ipk-specific settings"
+				},
+				"name": {
+					"type": "string",
+					"title": "package name"
+				},
+				"arch": {
+					"type": "string",
+					"title": "target architecture",
+					"examples": [
+						"amd64"
+					]
+				},
+				"platform": {
+					"type": "string",
+					"title": "target platform",
+					"default": "linux",
+					"examples": [
+						"linux"
+					]
+				},
+				"epoch": {
+					"type": "string",
+					"title": "version epoch",
+					"default": "extracted from version",
+					"examples": [
+						"2"
+					]
+				},
+				"version": {
+					"type": "string",
+					"title": "version",
+					"examples": [
+						"v1.0.2",
+						"2.0.1"
+					]
+				},
+				"version_schema": {
+					"type": "string",
+					"enum": [
+						"semver",
+						"none"
+					],
+					"title": "version schema",
+					"default": "semver"
+				},
+				"release": {
+					"type": "string",
+					"title": "version release",
+					"examples": [
+						"1"
+					]
+				},
+				"prerelease": {
+					"type": "string",
+					"title": "version prerelease",
+					"default": "extracted from version"
+				},
+				"version_metadata": {
+					"type": "string",
+					"title": "version metadata",
+					"examples": [
+						"git"
+					]
+				},
+				"section": {
+					"type": "string",
+					"title": "package section",
+					"examples": [
+						"default"
+					]
+				},
+				"priority": {
+					"type": "string",
+					"title": "package priority",
+					"examples": [
+						"extra"
+					]
+				},
+				"maintainer": {
+					"type": "string",
+					"title": "package maintainer",
+					"examples": [
+						"me@example.com"
+					]
+				},
+				"description": {
+					"type": "string",
+					"title": "package description"
+				},
+				"vendor": {
+					"type": "string",
+					"title": "package vendor",
+					"examples": [
+						"MyCorp"
+					]
+				},
+				"homepage": {
+					"type": "string",
+					"title": "package homepage",
+					"examples": [
+						"https://example.com"
+					]
+				},
+				"license": {
+					"type": "string",
+					"title": "package license",
+					"examples": [
+						"MIT"
+					]
+				},
+				"changelog": {
+					"type": "string",
+					"title": "package changelog",
+					"description": "see https://github.com/goreleaser/chglog for more details",
+					"examples": [
+						"changelog.yaml"
+					]
+				},
+				"disable_globbing": {
+					"type": "boolean",
+					"title": "whether to disable file globbing",
+					"default": false
+				},
+				"mtime": {
+					"type": "string",
+					"format": "date-time",
+					"title": "time to set into the files generated by nFPM"
+				},
+				"overrides": {
+					"additionalProperties": {
+						"$ref": "#/$defs/Overridables"
+					},
+					"type": "object",
+					"title": "overrides",
+					"description": "override some fields when packaging with a specific packager"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"name",
+				"arch",
+				"version"
+			]
+		},
+		"Content": {
+			"properties": {
+				"src": {
+					"type": "string"
+				},
+				"dst": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string",
+					"enum": [
+						"symlink",
+						"ghost",
+						"config",
+						"config|noreplace",
+						"dir",
+						"tree",
+						""
+					],
+					"default": ""
+				},
+				"packager": {
+					"type": "string"
+				},
+				"file_info": {
+					"$ref": "#/$defs/ContentFileInfo"
+				},
+				"expand": {
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"dst"
+			]
+		},
+		"ContentFileInfo": {
+			"properties": {
+				"owner": {
+					"type": "string"
+				},
+				"group": {
+					"type": "string"
+				},
+				"mode": {
+					"type": "integer"
+				},
+				"mtime": {
+					"type": "string",
+					"format": "date-time"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"Contents": {
+			"items": {
+				"$ref": "#/$defs/Content"
+			},
+			"type": "array"
+		},
+		"Deb": {
+			"properties": {
+				"arch": {
+					"type": "string",
+					"title": "architecture in deb nomenclature"
+				},
+				"scripts": {
+					"$ref": "#/$defs/DebScripts",
+					"title": "scripts"
+				},
+				"triggers": {
+					"$ref": "#/$defs/DebTriggers",
+					"title": "triggers"
+				},
+				"breaks": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"title": "breaks"
+				},
+				"signature": {
+					"$ref": "#/$defs/DebSignature",
+					"title": "signature"
+				},
+				"compression": {
+					"type": "string",
+					"enum": [
+						"gzip",
+						"xz",
+						"none"
+					],
+					"title": "compression algorithm to be used",
+					"default": "gzip"
+				},
+				"fields": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"type": "object",
+					"title": "fields"
+				},
+				"predepends": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "predepends directive"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"DebScripts": {
+			"properties": {
+				"rules": {
+					"type": "string",
+					"title": "rules"
+				},
+				"templates": {
+					"type": "string",
+					"title": "templates"
+				},
+				"config": {
+					"type": "string",
+					"title": "config"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"DebSignature": {
+			"properties": {
+				"key_file": {
+					"type": "string",
+					"title": "key file",
+					"examples": [
+						"key.gpg"
+					]
+				},
+				"key_id": {
+					"type": "string",
+					"title": "key id",
+					"examples": [
+						"bc8acdd415bd80b3"
+					]
+				},
+				"method": {
+					"type": "string",
+					"enum": [
+						"debsign"
+					],
+					"title": "method role",
+					"default": "debsign"
+				},
+				"type": {
+					"type": "string",
+					"enum": [
+						"origin",
+						"maint",
+						"archive"
+					],
+					"title": "signer role",
+					"default": "origin"
+				},
+				"signer": {
+					"type": "string",
+					"title": "signer"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"DebTriggers": {
+			"properties": {
+				"interest": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"title": "interest"
+				},
+				"interest_await": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"title": "interest await"
+				},
+				"interest_noawait": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"title": "interest noawait"
+				},
+				"activate": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"title": "activate"
+				},
+				"activate_await": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"title": "activate await"
+				},
+				"activate_noawait": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"title": "activate noawait"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"IPK": {
+			"properties": {
+				"abi_version": {
+					"type": "string",
+					"title": "abi version"
+				},
+				"alternatives": {
+					"items": {
+						"$ref": "#/$defs/IPKAlternative"
+					},
+					"type": "array",
+					"title": "alternatives"
+				},
+				"arch": {
+					"type": "string",
+					"title": "architecture in deb nomenclature"
+				},
+				"auto_installed": {
+					"type": "boolean",
+					"title": "auto installed",
+					"default": false
+				},
+				"essential": {
+					"type": "boolean",
+					"title": "whether package is essential",
+					"default": false
+				},
+				"fields": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"type": "object",
+					"title": "fields"
+				},
+				"predepends": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "predepends directive"
+				},
+				"tags": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"title": "tags"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"IPKAlternative": {
+			"properties": {
+				"priority": {
+					"type": "integer",
+					"title": "priority"
+				},
+				"target": {
+					"type": "string",
+					"title": "target"
+				},
+				"link_name": {
+					"type": "string",
+					"title": "link name"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"Overridables": {
+			"properties": {
+				"replaces": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "replaces directive"
+				},
+				"provides": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "provides directive"
+				},
+				"depends": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "depends directive"
+				},
+				"recommends": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "recommends directive"
+				},
+				"suggests": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "suggests directive"
+				},
+				"conflicts": {
+					"items": {
+						"type": "string",
+						"examples": [
+							"nfpm"
+						]
+					},
+					"type": "array",
+					"title": "conflicts directive"
+				},
+				"contents": {
+					"$ref": "#/$defs/Contents",
+					"title": "files to add to the package"
+				},
+				"umask": {
+					"type": "integer",
+					"title": "umask for file contents",
+					"examples": [
+						112
+					]
+				},
+				"scripts": {
+					"$ref": "#/$defs/Scripts",
+					"title": "scripts to execute"
+				},
+				"rpm": {
+					"$ref": "#/$defs/RPM",
+					"title": "rpm-specific settings"
+				},
+				"deb": {
+					"$ref": "#/$defs/Deb",
+					"title": "deb-specific settings"
+				},
+				"apk": {
+					"$ref": "#/$defs/APK",
+					"title": "apk-specific settings"
+				},
+				"archlinux": {
+					"$ref": "#/$defs/ArchLinux",
+					"title": "archlinux-specific settings"
+				},
+				"ipk": {
+					"$ref": "#/$defs/IPK",
+					"title": "ipk-specific settings"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"RPM": {
+			"properties": {
+				"arch": {
+					"type": "string",
+					"title": "architecture in rpm nomenclature"
+				},
+				"scripts": {
+					"$ref": "#/$defs/RPMScripts",
+					"title": "rpm-specific scripts"
+				},
+				"group": {
+					"type": "string",
+					"title": "package group",
+					"examples": [
+						"Unspecified"
+					]
+				},
+				"summary": {
+					"type": "string",
+					"title": "package summary"
+				},
+				"compression": {
+					"type": "string",
+					"enum": [
+						"gzip",
+						"lzma",
+						"xz"
+					],
+					"title": "compression algorithm to be used",
+					"default": "gzip:-1"
+				},
+				"signature": {
+					"$ref": "#/$defs/RPMSignature",
+					"title": "rpm signature"
+				},
+				"packager": {
+					"type": "string",
+					"title": "organization that actually packaged the software"
+				},
+				"buildhost": {
+					"type": "string",
+					"title": "hostname of the building server, default=os.Hostname()"
+				},
+				"prefixes": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"title": "Prefixes for relocatable packages"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"RPMScripts": {
+			"properties": {
+				"pretrans": {
+					"type": "string",
+					"title": "pretrans script"
+				},
+				"posttrans": {
+					"type": "string",
+					"title": "posttrans script"
+				},
+				"verify": {
+					"type": "string",
+					"title": "verify script"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"RPMSignature": {
+			"properties": {
+				"key_file": {
+					"type": "string",
+					"title": "key file",
+					"examples": [
+						"key.gpg"
+					]
+				},
+				"key_id": {
+					"type": "string",
+					"title": "key id",
+					"examples": [
+						"bc8acdd415bd80b3"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"Scripts": {
+			"properties": {
+				"preinstall": {
+					"type": "string",
+					"title": "pre install"
+				},
+				"postinstall": {
+					"type": "string",
+					"title": "post install"
+				},
+				"preremove": {
+					"type": "string",
+					"title": "pre remove"
+				},
+				"postremove": {
+					"type": "string",
+					"title": "post remove"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		}
+	},
+	"description": "nFPM configuration definition file"
+}


### PR DESCRIPTION
This commit adds the BuildHost option to the RPM specific configurations. If the build host is not provided it will default to os.Hostname() which is the previous behavior. This allows reproduce-able builds when the build environment spans multiple hosts.