### PR TITLE
Corrected amd64 name for deb in goarch-to-pkg.md

### DIFF
--- a/www/docs/goarch-to-pkg.md
+++ b/www/docs/goarch-to-pkg.md
@@ -19,7 +19,7 @@ Thank you!
 | GOARCH | Value |
 | :--: | :--: |
 | `386` | `i386` |
-| `amd64` | `x86_64` |
+| `amd64` | `amd64` |
 | `arm64` | `arm64` |
 | `arm5` | `armel` |
 | `arm6` | `armhf` |


### PR DESCRIPTION
The actual code seems to leave GOARCH="amd64" as "amd64" for deb packages:
https://github.com/goreleaser/nfpm/blob/8e999742a1ba06e2a68bd461e39b16eef8e4c669/deb/deb.go#L42-L52

(If I am correct that being absent from that map means that a string will be used without changes.)

However, the documentation currently claims that it will be mapped to "x86_64".

Just to be clear, I believe that the code [is correct](https://www.debian.org/ports/#portlist-released). The value  "x86_64", as used in the documentation, is correct for rpm but not for deb. This PR aims to change the documentation to match the code.