### PR TITLE
Improve version extraction of `systemctl`

### DIFF
--- a/www/docs/tips.md
+++ b/www/docs/tips.md
@@ -40,7 +40,7 @@ systemd_version=0
 if ! command -V systemctl >/dev/null 2>&1; then
   use_systemctl="False"
 else
-    systemd_version=$(systemctl --version | head -1  | grep -E -o "[0-9]+" | head -1)
+    systemd_version=$(systemctl --version | head -1 | grep -E -o "[0-9]+" | head -1)
 fi
 
 cleanup() {

--- a/www/docs/tips.md
+++ b/www/docs/tips.md
@@ -40,7 +40,7 @@ systemd_version=0
 if ! command -V systemctl >/dev/null 2>&1; then
   use_systemctl="False"
 else
-    systemd_version=$(systemctl --version | head -1 | sed 's/systemd //g')
+    systemd_version=$(systemctl --version | head -1  | grep -E -o "[0-9]+" | head -1)
 fi
 
 cleanup() {


### PR DESCRIPTION
On my Raspberry Pi, the first line of `systemctl --version` looks like this :

```
systemd 252 (252.36-1~deb12u1)
```

The `systemd_version` variable should be an integer because it is compared to 231 a couple of line further.

In the proposed change, I use `grep` instead of `sed`. The `grep` command prints all integers from the line, and the second `head -1` keeps the first integer only.