### PR TITLE
The debian image now supports zstd compression

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -175,19 +175,13 @@ func TestDebCompression(t *testing.T) {
 						t.Skip("ppc64le arch not supported in pipeline")
 					}
 
-					target := "compression"
-					if testCompFormat == "zstd" {
-						// we can remove this exception as soon as the debian image supports zstd
-						target = "zstdcompression"
-					}
-
 					accept(t, acceptParms{
 						Name:   fmt.Sprintf("%s_compression_%s", testCompFormat, testArch),
 						Conf:   fmt.Sprintf("deb.%s.compression.yaml", testCompFormat),
 						Format: format,
 						Docker: dockerParams{
 							File:   fmt.Sprintf("%s.dockerfile", format),
-							Target: target,
+							Target: "compression",
 							Arch:   testArch,
 						},
 					})

--- a/testdata/acceptance/deb.dockerfile
+++ b/testdata/acceptance/deb.dockerfile
@@ -193,20 +193,6 @@ RUN echo wat >> /etc/foo/whatever.conf
 RUN dpkg -r foo
 RUN test ! -f /usr/bin/fake
 
-# ---- zstdcompression test ----
-# we can use the regular compression image as
-# soon as zstd is supported on debian
-FROM ubuntu AS zstdcompression
-ARG package
-RUN echo "${package}"
-COPY ${package} /tmp/foo.deb
-RUN dpkg -i /tmp/foo.deb
-RUN test -e /usr/bin/fake
-RUN test -f /etc/foo/whatever.conf
-RUN echo wat >> /etc/foo/whatever.conf
-RUN dpkg -r foo
-RUN test ! -f /usr/bin/fake
-
 # ---- upgrade test ----
 FROM test_base AS upgrade
 ARG oldpackage


### PR DESCRIPTION
Old comment was from `debian:11`, supported since `debian:12`

Current test image is already based on `debian:13` (`trixie`).