### PR TITLE
apk/rpm: Correctly configure arch for loongarch64

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -58,6 +58,7 @@ func init() {
 }
 
 // https://wiki.alpinelinux.org/wiki/Architecture
+// https://github.com/golang/go/blob/master/src/internal/syslist/syslist.go
 // nolint: gochecknoglobals
 var archToAlpine = map[string]string{
 	"386":     "x86",
@@ -67,6 +68,7 @@ var archToAlpine = map[string]string{
 	"arm7":    "armv7",
 	"ppc64le": "ppc64le",
 	"s390":    "s390x",
+	"loong64": "loongarch64",
 }
 
 func ensureValidArch(info *nfpm.Info) *nfpm.Info {

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -39,6 +39,7 @@ func init() {
 	nfpm.RegisterPackager(packagerName, Default)
 }
 
+// https://wiki.debian.org/ArchitectureSpecificsMemo
 // nolint: gochecknoglobals
 var archToDebian = map[string]string{
 	"386":      "i386",

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -72,6 +72,7 @@ type RPM struct {
 }
 
 // https://docs.fedoraproject.org/ro/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch01s03.html
+// https://github.com/rpm-software-management/rpm/blob/4a9b7b5908d8b463a836b51322242677677bd8b7/lib/rpmrc.cc#L1167
 // nolint: gochecknoglobals
 var archToRPM = map[string]string{
 	"all":      "noarch",
@@ -84,6 +85,7 @@ var archToRPM = map[string]string{
 	"mips64le": "mips64el",
 	"mipsle":   "mipsel",
 	"mips":     "mips",
+	"loong64":  "loongarch64",
 	// TODO: other arches
 }
 


### PR DESCRIPTION
Sources:
+ https://wiki.alpinelinux.org/wiki/Architecture
+ https://github.com/alpinelinux/apk-tools/blob/f724dcd2de54bc16b73f8a4295802a1655dc4ea5/doc/apk-package.5.scd?plain=1#L110
+ https://github.com/search?q=repo%3Arpm-software-management%2Frpm%20loongarch64&type=code
+ https://wiki.debian.org/Ports/loong64 (DEB ARCH is loong64)