### PR TITLE
fix(apk): handle all/noarch

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -61,6 +61,7 @@ func init() {
 // https://github.com/golang/go/blob/master/src/internal/syslist/syslist.go
 // nolint: gochecknoglobals
 var archToAlpine = map[string]string{
+	"all":     "noarch",
 	"386":     "x86",
 	"amd64":   "x86_64",
 	"arm64":   "aarch64",

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -518,7 +518,7 @@ func TestAPKConventionalFileName(t *testing.T) {
 		},
 		{
 			Arch: "all", Version: "1.2.3",
-			Expect: "default_1.2.3_all.apk",
+			Expect: "default_1.2.3_noarch.apk",
 		},
 		{
 			Arch: "386", Version: "1.2.3", Release: "1", Prerelease: "beta1",


### PR DESCRIPTION
According to the APKBUILD Reference, the  arch  variable can be set to:

- Specific architectures (x86, x86_64, armv7, armhf, aarch64, ppc64le, s390x, riscv64)
- all: means the package runs on all architectures
- noarch: means it's architecture-independent (e.g., a pure-python package)

I'm not sure if we should keep all or noarch, or maybe leave as is and support both? In that case, needs to be consistent in the other packagers.