### PR TITLE
fix: remove invalid License field from deb control

### DIFF
--- a/deb/deb.go
+++ b/deb/deb.go
@@ -785,9 +785,6 @@ Architecture: {{ if ne .Info.Platform "linux"}}{{ .Info.Platform }}-{{ end }}{{.
 {{- if .Info.Deb.ArchVariant}}
 Architecture-Variant: {{ .Info.Deb.ArchVariant }}
 {{- end }}
-{{- if .Info.License }}
-License: {{.Info.License}}
-{{- end }}
 {{- if .Info.Maintainer}}
 Maintainer: {{.Info.Maintainer}}
 {{- end }}

--- a/deb/testdata/bad_provides.golden
+++ b/deb/testdata/bad_provides.golden
@@ -3,7 +3,6 @@ Version: 1.0.0
 Section: default
 Priority: extra
 Architecture: amd64
-License: MIT
 Maintainer: Carlos A Becker <pkg@carlosbecker.com>
 Installed-Size: 0
 Replaces: svn

--- a/deb/testdata/control.golden
+++ b/deb/testdata/control.golden
@@ -3,7 +3,6 @@ Version: 1.0.0
 Section: default
 Priority: extra
 Architecture: amd64
-License: MIT
 Maintainer: Carlos A Becker <pkg@carlosbecker.com>
 Installed-Size: 10
 Replaces: svn


### PR DESCRIPTION
Debian policy does not recognize License as a valid control field, causing lintian to emit `unknown-field License` warnings.

Closes #1033

Assisted-by: Claude Opus 4.6 via Crush <crush@charm.land>