### PR TITLE
feat: add support for signing archlinux packages

### DIFF
--- a/arch/arch.go
+++ b/arch/arch.go
@@ -3,6 +3,7 @@ package arch
 
 import (
 	"archive/tar"
+	"bufio"
 	"bytes"
 	"crypto/md5"
 	"crypto/sha256"
@@ -19,6 +20,7 @@ import (
 	"github.com/goreleaser/nfpm/v2/files"
 	"github.com/goreleaser/nfpm/v2/internal/maps"
 	"github.com/goreleaser/nfpm/v2/internal/modtime"
+	"github.com/goreleaser/nfpm/v2/internal/sign"
 	"github.com/klauspost/compress/zstd"
 	"github.com/klauspost/pgzip"
 )
@@ -134,10 +136,8 @@ func (ArchLinux) Package(info *nfpm.Info, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	defer zw.Close()
 
 	tw := tar.NewWriter(zw)
-	defer tw.Close()
 
 	entries, totalSize, err := createFilesInTar(info, tw)
 	if err != nil {
@@ -157,7 +157,32 @@ func (ArchLinux) Package(info *nfpm.Info, w io.Writer) error {
 		return fmt.Errorf("create mtree: %w", err)
 	}
 
-	return createScripts(info, tw)
+	err = createScripts(info, tw)
+	if err != nil {
+		return fmt.Errorf("create scripts: %w", err)
+	}
+
+	// finalize the tar/zstd writer before creating the signature
+	tw.Close()
+	zw.Close()
+
+	if info.ArchLinux.Signature.KeyFile != "" || info.ArchLinux.Signature.SignFn != nil {
+		sig, err := createSignature(info)
+		if err != nil {
+			return &nfpm.ErrSigningFailure{
+				Err: fmt.Errorf("create signature: %w", err),
+			}
+		}
+
+		err = createSignatureFile(info, sig)
+		if err != nil {
+			return &nfpm.ErrSigningFailure{
+				Err: fmt.Errorf("create signature file: %w", err),
+			}
+		}
+	}
+
+	return nil
 }
 
 // ConventionalExtension returns the file name conventionally used for Arch Linux packages
@@ -400,6 +425,42 @@ func createPkginfo(info *nfpm.Info, tw *tar.Writer, totalSize int64) (*MtreeEntr
 		MD5:         md5Hash.Sum(nil),
 		SHA256:      sha256Hash.Sum(nil),
 	}, nil
+}
+
+func createSignature(info *nfpm.Info) ([]byte, error) {
+	f, err := os.Open(info.Target)
+	if err != nil {
+		return nil, fmt.Errorf("open package for signing: %w", err)
+	}
+	defer f.Close()
+
+	data := bufio.NewReader(f)
+
+	var sig []byte
+	if signFn := info.ArchLinux.Signature.SignFn; signFn != nil {
+		sig, err = signFn(data)
+	} else {
+		sig, err = sign.PGPDetachedSignWithKeyID(data, info.ArchLinux.Signature.KeyFile, info.ArchLinux.Signature.KeyPassphrase, info.ArchLinux.Signature.KeyID)
+		if err != nil {
+			return nil, fmt.Errorf("create signature: %w", err)
+		}
+	}
+	return sig, nil
+}
+
+func createSignatureFile(info *nfpm.Info, sig []byte) error {
+	sigFile, err := os.Create(info.Target + ".sig")
+	if err != nil {
+		return fmt.Errorf("create signature file: %w", err)
+	}
+	defer sigFile.Close()
+
+	_, err = sigFile.Write(sig)
+	if err != nil {
+		return fmt.Errorf("write signature to file: %w", err)
+	}
+
+	return nil
 }
 
 func writeKVPairs(w io.Writer, pairs map[string]string) error {

--- a/arch/arch.go
+++ b/arch/arch.go
@@ -3,6 +3,7 @@ package arch
 
 import (
 	"archive/tar"
+	"bufio"
 	"bytes"
 	"crypto/md5"
 	"crypto/sha256"
@@ -19,6 +20,7 @@ import (
 	"github.com/goreleaser/nfpm/v2/files"
 	"github.com/goreleaser/nfpm/v2/internal/maps"
 	"github.com/goreleaser/nfpm/v2/internal/modtime"
+	"github.com/goreleaser/nfpm/v2/internal/sign"
 	"github.com/klauspost/compress/zstd"
 	"github.com/klauspost/pgzip"
 )
@@ -158,7 +160,34 @@ func (ArchLinux) Package(info *nfpm.Info, w io.Writer) error {
 		return fmt.Errorf("create mtree: %w", err)
 	}
 
-	return createScripts(info, tw)
+	if err = createScripts(info, tw); err != nil {
+		return fmt.Errorf("create scripts: %w", err)
+	}
+
+	// finalize the tar/zstd writer before creating the signature
+	if err = tw.Close(); err != nil {
+		return fmt.Errorf("closing data tarball: %w", err)
+	}
+	if err = zw.Close(); err != nil {
+		return fmt.Errorf("closing zstd writer: %w", err)
+	}
+
+	if info.ArchLinux.Signature.KeyFile != "" || info.ArchLinux.Signature.SignFn != nil {
+		sig, err := createSignature(info)
+		if err != nil {
+			return &nfpm.ErrSigningFailure{
+				Err: fmt.Errorf("create signature: %w", err),
+			}
+		}
+
+		if err = createSignatureFile(info, sig); err != nil {
+			return &nfpm.ErrSigningFailure{
+				Err: fmt.Errorf("create signature file: %w", err),
+			}
+		}
+	}
+
+	return nil
 }
 
 // ConventionalExtension returns the file name conventionally used for Arch Linux packages
@@ -401,6 +430,45 @@ func createPkginfo(info *nfpm.Info, tw *tar.Writer, totalSize int64) (*MtreeEntr
 		MD5:         md5Hash.Sum(nil),
 		SHA256:      sha256Hash.Sum(nil),
 	}, nil
+}
+
+func createSignature(info *nfpm.Info) ([]byte, error) {
+	f, err := os.Open(info.Target)
+	if err != nil {
+		return nil, fmt.Errorf("open package for signing: %w", err)
+	}
+	defer f.Close()
+
+	data := bufio.NewReader(f)
+
+	var sig []byte
+	if signFn := info.ArchLinux.Signature.SignFn; signFn != nil {
+		sig, err = signFn(data)
+		if err != nil {
+			return nil, fmt.Errorf("create signature: %w", err)
+		}
+	} else {
+		sig, err = sign.PGPDetachedSignWithKeyID(data, info.ArchLinux.Signature.KeyFile, info.ArchLinux.Signature.KeyPassphrase, info.ArchLinux.Signature.KeyID)
+		if err != nil {
+			return nil, fmt.Errorf("create signature: %w", err)
+		}
+	}
+	return sig, nil
+}
+
+func createSignatureFile(info *nfpm.Info, sig []byte) error {
+	sigFile, err := os.Create(info.Target + ".sig")
+	if err != nil {
+		return fmt.Errorf("create signature file: %w", err)
+	}
+	defer sigFile.Close()
+
+	_, err = sigFile.Write(sig)
+	if err != nil {
+		return fmt.Errorf("write signature to file: %w", err)
+	}
+
+	return nil
 }
 
 func writeKVPairs(w io.Writer, pairs map[string]string) error {

--- a/arch/arch_test.go
+++ b/arch/arch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/goreleaser/nfpm/v2"
 	"github.com/goreleaser/nfpm/v2/files"
+	"github.com/goreleaser/nfpm/v2/internal/sign"
 	"github.com/klauspost/compress/zstd"
 	"github.com/klauspost/pgzip"
 	"github.com/stretchr/testify/require"
@@ -208,6 +209,56 @@ func TestArchOverrideArchitecture(t *testing.T) {
 	require.Equal(t, "randomarch", fields["arch"])
 }
 
+func TestArchSignature(t *testing.T) {
+	info := exampleInfo()
+	info.ArchLinux.Signature.KeyFile = "../internal/sign/testdata/privkey.asc"
+	info.ArchLinux.Signature.KeyPassphrase = "hunter2"
+
+	f, err := os.CreateTemp(t.TempDir(), info.Target)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+	info.Target = f.Name()
+	require.NoError(t, Default.Package(info, f))
+
+	signature, err := os.ReadFile(info.Target + ".sig")
+	require.NoError(t, err)
+
+	f.Seek(0, io.SeekStart)
+	err = sign.PGPVerify(f, signature, "../internal/sign/testdata/pubkey.asc")
+	require.NoError(t, err)
+}
+
+func TestArchSignatureError(t *testing.T) {
+	info := exampleInfo()
+	info.ArchLinux.Signature.KeyFile = "/does/not/exist"
+
+	var pkg bytes.Buffer
+	err := Default.Package(info, &pkg)
+	require.Error(t, err)
+
+	var expectedError *nfpm.ErrSigningFailure
+	require.ErrorAs(t, err, &expectedError)
+}
+
+func TestArchSignatureCallback(t *testing.T) {
+	info := exampleInfo()
+	info.ArchLinux.Signature.SignFn = func(r io.Reader) ([]byte, error) {
+		return sign.PGPArmoredDetachSignWithKeyID(r, "../internal/sign/testdata/privkey.asc", "hunter2", nil)
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), info.Target)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+	info.Target = f.Name()
+	require.NoError(t, Default.Package(info, f))
+
+	signature, err := os.ReadFile(info.Target + ".sig")
+	require.NoError(t, err)
+
+	f.Seek(0, io.SeekStart)
+	err = sign.PGPVerify(f, signature, "../internal/sign/testdata/pubkey.asc")
+	require.NoError(t, err)
+}
 func makeTestPkginfo(t *testing.T, info *nfpm.Info) ([]byte, error) {
 	t.Helper()
 

--- a/arch/arch_test.go
+++ b/arch/arch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/goreleaser/nfpm/v2"
 	"github.com/goreleaser/nfpm/v2/files"
+	"github.com/goreleaser/nfpm/v2/internal/sign"
 	"github.com/klauspost/compress/zstd"
 	"github.com/klauspost/pgzip"
 	"github.com/stretchr/testify/require"
@@ -207,6 +208,59 @@ func TestArchOverrideArchitecture(t *testing.T) {
 	require.NoError(t, err)
 	fields := extractPkginfoFields(pkginfoData)
 	require.Equal(t, "randomarch", fields["arch"])
+}
+
+func TestArchSignature(t *testing.T) {
+	info := exampleInfo()
+	info.ArchLinux.Signature.KeyFile = "../internal/sign/testdata/privkey.asc"
+	info.ArchLinux.Signature.KeyPassphrase = "hunter2"
+
+	f, err := os.CreateTemp(t.TempDir(), info.Target)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+	info.Target = f.Name()
+	require.NoError(t, Default.Package(info, f))
+
+	signature, err := os.ReadFile(info.Target + ".sig")
+	require.NoError(t, err)
+
+	_, err = f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	err = sign.PGPVerify(f, signature, "../internal/sign/testdata/pubkey.asc")
+	require.NoError(t, err)
+}
+
+func TestArchSignatureError(t *testing.T) {
+	info := exampleInfo()
+	info.ArchLinux.Signature.KeyFile = "/does/not/exist"
+
+	var pkg bytes.Buffer
+	err := Default.Package(info, &pkg)
+	require.Error(t, err)
+
+	var expectedError *nfpm.ErrSigningFailure
+	require.ErrorAs(t, err, &expectedError)
+}
+
+func TestArchSignatureCallback(t *testing.T) {
+	info := exampleInfo()
+	info.ArchLinux.Signature.SignFn = func(r io.Reader) ([]byte, error) {
+		return sign.PGPArmoredDetachSignWithKeyID(r, "../internal/sign/testdata/privkey.asc", "hunter2", nil)
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), info.Target)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+	info.Target = f.Name()
+	require.NoError(t, Default.Package(info, f))
+
+	signature, err := os.ReadFile(info.Target + ".sig")
+	require.NoError(t, err)
+
+	_, err = f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	err = sign.PGPVerify(f, signature, "../internal/sign/testdata/pubkey.asc")
+	require.NoError(t, err)
 }
 
 func makeTestPkginfo(t *testing.T, info *nfpm.Info) ([]byte, error) {

--- a/internal/sign/pgp.go
+++ b/internal/sign/pgp.go
@@ -20,32 +20,37 @@ import (
 // signature and is compatible with rpmpack's signature API.
 func PGPSignerWithKeyID(keyFile, passphrase string, hexKeyID *string) func([]byte) ([]byte, error) {
 	return func(data []byte) ([]byte, error) {
-		keyID, err := parseKeyID(hexKeyID)
-		if err != nil {
-			return nil, fmt.Errorf("%v is not a valid key id: %w", hexKeyID, err)
-		}
-
-		key, err := readSigningKey(keyFile, passphrase)
+		sig, err := PGPArmoredDetachSignWithKeyID(bytes.NewReader(data), keyFile, passphrase, hexKeyID)
 		if err != nil {
 			return nil, &nfpm.ErrSigningFailure{Err: err}
 		}
-
-		var signature bytes.Buffer
-
-		if err := openpgp.DetachSign(
-			&signature,
-			key,
-			bytes.NewReader(data),
-			&packet.Config{
-				SigningKeyId: keyID,
-				DefaultHash:  crypto.SHA256,
-			},
-		); err != nil {
-			return nil, &nfpm.ErrSigningFailure{Err: err}
-		}
-
-		return signature.Bytes(), nil
+		return sig, nil
 	}
+}
+
+// PGPDetachedSignWithKeyID creates a detached signature.
+func PGPDetachedSignWithKeyID(message io.Reader, keyFile, passphrase string, hexKeyID *string) ([]byte, error) {
+	keyID, err := parseKeyID(hexKeyID)
+	if err != nil {
+		return nil, fmt.Errorf("%v is not a valid key id: %w", hexKeyID, err)
+	}
+
+	key, err := readSigningKey(keyFile, passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("detach sign: %w", err)
+	}
+
+	var signature bytes.Buffer
+
+	err = openpgp.DetachSign(&signature, key, message, &packet.Config{
+		SigningKeyId: keyID,
+		DefaultHash:  crypto.SHA256,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("detach sign: %w", err)
+	}
+
+	return signature.Bytes(), nil
 }
 
 // PGPArmoredDetachSign creates an ASCII-armored detached signature.

--- a/internal/sign/pgp.go
+++ b/internal/sign/pgp.go
@@ -20,32 +20,37 @@ import (
 // signature and is compatible with rpmpack's signature API.
 func PGPSignerWithKeyID(keyFile, passphrase string, hexKeyID *string) func([]byte) ([]byte, error) {
 	return func(data []byte) ([]byte, error) {
-		keyID, err := parseKeyID(hexKeyID)
-		if err != nil {
-			return nil, fmt.Errorf("%v is not a valid key id: %w", hexKeyID, err)
-		}
-
-		key, err := readSigningKey(keyFile, passphrase)
+		sig, err := PGPDetachedSignWithKeyID(bytes.NewReader(data), keyFile, passphrase, hexKeyID)
 		if err != nil {
 			return nil, &nfpm.ErrSigningFailure{Err: err}
 		}
-
-		var signature bytes.Buffer
-
-		if err := openpgp.DetachSign(
-			&signature,
-			key,
-			bytes.NewReader(data),
-			&packet.Config{
-				SigningKeyId: keyID,
-				DefaultHash:  crypto.SHA256,
-			},
-		); err != nil {
-			return nil, &nfpm.ErrSigningFailure{Err: err}
-		}
-
-		return signature.Bytes(), nil
+		return sig, nil
 	}
+}
+
+// PGPDetachedSignWithKeyID creates a detached non-ASCII-armored signature.
+func PGPDetachedSignWithKeyID(message io.Reader, keyFile, passphrase string, hexKeyID *string) ([]byte, error) {
+	keyID, err := parseKeyID(hexKeyID)
+	if err != nil {
+		return nil, fmt.Errorf("%v is not a valid key id: %w", hexKeyID, err)
+	}
+
+	key, err := readSigningKey(keyFile, passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("detach sign: %w", err)
+	}
+
+	var signature bytes.Buffer
+
+	err = openpgp.DetachSign(&signature, key, message, &packet.Config{
+		SigningKeyId: keyID,
+		DefaultHash:  crypto.SHA256,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("detach sign: %w", err)
+	}
+
+	return signature.Bytes(), nil
 }
 
 // PGPArmoredDetachSign creates an ASCII-armored detached signature.

--- a/internal/sign/pgp_test.go
+++ b/internal/sign/pgp_test.go
@@ -63,6 +63,37 @@ func TestPGPSignerAndVerify(t *testing.T) {
 	}
 }
 
+func TestDetachSignAndVerify(t *testing.T) {
+	data := []byte("testdata")
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			armoredPublicKey := fmt.Sprintf("%s.asc", testCase.pubKeyFile)
+			gpgPublicKey := fmt.Sprintf("%s.gpg", testCase.pubKeyFile)
+			sig, err := PGPDetachedSignWithKeyID(
+				bytes.NewReader(data),
+				testCase.privKeyFile,
+				testCase.pass,
+				testCase.keyID,
+			)
+			require.NoError(t, err)
+
+			err = PGPVerify(bytes.NewReader(data), sig, armoredPublicKey)
+			require.NoError(t, err)
+
+			err = PGPVerify(bytes.NewReader(data), sig, gpgPublicKey)
+			require.NoError(t, err)
+			if testCase.keyID != nil {
+				var pgpSignature *crypto.PGPSignature
+				pgpSignature = crypto.NewPGPSignature(sig)
+
+				sigID, _ := pgpSignature.GetSignatureKeyIDs()
+				require.Len(t, sigID, 1)
+				require.Equal(t, *testCase.keyID, fmt.Sprintf("%x", sigID[0]))
+			}
+		})
+	}
+}
+
 func TestArmoredDetachSignAndVerify(t *testing.T) {
 	data := []byte("testdata")
 	for _, testCase := range testCases {

--- a/internal/sign/pgp_test.go
+++ b/internal/sign/pgp_test.go
@@ -63,6 +63,36 @@ func TestPGPSignerAndVerify(t *testing.T) {
 	}
 }
 
+func TestDetachSignAndVerify(t *testing.T) {
+	data := []byte("testdata")
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			armoredPublicKey := fmt.Sprintf("%s.asc", testCase.pubKeyFile)
+			gpgPublicKey := fmt.Sprintf("%s.gpg", testCase.pubKeyFile)
+			sig, err := PGPDetachedSignWithKeyID(
+				bytes.NewReader(data),
+				testCase.privKeyFile,
+				testCase.pass,
+				testCase.keyID,
+			)
+			require.NoError(t, err)
+
+			err = PGPVerify(bytes.NewReader(data), sig, armoredPublicKey)
+			require.NoError(t, err)
+
+			err = PGPVerify(bytes.NewReader(data), sig, gpgPublicKey)
+			require.NoError(t, err)
+			if testCase.keyID != nil {
+				pgpSignature := crypto.NewPGPSignature(sig)
+
+				sigID, _ := pgpSignature.GetSignatureKeyIDs()
+				require.Len(t, sigID, 1)
+				require.Equal(t, *testCase.keyID, fmt.Sprintf("%x", sigID[0]))
+			}
+		})
+	}
+}
+
 func TestArmoredDetachSignAndVerify(t *testing.T) {
 	data := []byte("testdata")
 	for _, testCase := range testCases {

--- a/nfpm.go
+++ b/nfpm.go
@@ -238,15 +238,18 @@ func (c *Config) expandEnvVars() {
 	c.Deb.Signature.KeyFile = os.Expand(c.Deb.Signature.KeyFile, c.envMappingFunc)
 	c.RPM.Signature.KeyFile = os.Expand(c.RPM.Signature.KeyFile, c.envMappingFunc)
 	c.APK.Signature.KeyFile = os.Expand(c.APK.Signature.KeyFile, c.envMappingFunc)
+	c.ArchLinux.Signature.KeyFile = os.Expand(c.ArchLinux.Signature.KeyFile, c.envMappingFunc)
 	c.Deb.Signature.KeyID = pointer.ToString(os.Expand(pointer.GetString(c.Deb.Signature.KeyID), c.envMappingFunc))
 	c.RPM.Signature.KeyID = pointer.ToString(os.Expand(pointer.GetString(c.RPM.Signature.KeyID), c.envMappingFunc))
 	c.APK.Signature.KeyID = pointer.ToString(os.Expand(pointer.GetString(c.APK.Signature.KeyID), c.envMappingFunc))
+	c.ArchLinux.Signature.KeyID = pointer.ToString(os.Expand(pointer.GetString(c.ArchLinux.Signature.KeyID), c.envMappingFunc))
 
 	// Package signing passphrase
 	generalPassphrase := os.Expand("$NFPM_PASSPHRASE", c.envMappingFunc)
 	c.Deb.Signature.KeyPassphrase = generalPassphrase
 	c.RPM.Signature.KeyPassphrase = generalPassphrase
 	c.APK.Signature.KeyPassphrase = generalPassphrase
+	c.ArchLinux.Signature.KeyPassphrase = generalPassphrase
 
 	debPassphrase := os.Expand("$NFPM_DEB_PASSPHRASE", c.envMappingFunc)
 	if debPassphrase != "" {
@@ -261,6 +264,11 @@ func (c *Config) expandEnvVars() {
 	apkPassphrase := os.Expand("$NFPM_APK_PASSPHRASE", c.envMappingFunc)
 	if apkPassphrase != "" {
 		c.APK.Signature.KeyPassphrase = apkPassphrase
+	}
+
+	archlinuxPassphrase := os.Expand("$NFPM_ARCHLINUX_PASSPHRASE", c.envMappingFunc)
+	if archlinuxPassphrase != "" {
+		c.ArchLinux.Signature.KeyPassphrase = archlinuxPassphrase
 	}
 
 	// RPM specific
@@ -373,10 +381,15 @@ type Overridables struct {
 }
 
 type ArchLinux struct {
-	Pkgbase  string           `yaml:"pkgbase,omitempty" json:"pkgbase,omitempty" jsonschema:"title=explicitly specify the name used to refer to a split package, defaults to name"`
-	Arch     string           `yaml:"arch,omitempty" json:"arch,omitempty" jsonschema:"title=architecture in archlinux nomenclature"`
-	Packager string           `yaml:"packager,omitempty" json:"packager,omitempty" jsonschema:"title=organization that packaged the software"`
-	Scripts  ArchLinuxScripts `yaml:"scripts,omitempty" json:"scripts,omitempty" jsonschema:"title=archlinux-specific scripts"`
+	Pkgbase   string             `yaml:"pkgbase,omitempty" json:"pkgbase,omitempty" jsonschema:"title=explicitly specify the name used to refer to a split package, defaults to name"`
+	Arch      string             `yaml:"arch,omitempty" json:"arch,omitempty" jsonschema:"title=architecture in archlinux nomenclature"`
+	Packager  string             `yaml:"packager,omitempty" json:"packager,omitempty" jsonschema:"title=organization that packaged the software"`
+	Signature ArchLinuxSignature `yaml:"signature,omitempty" json:"signature,omitempty" jsonschema:"title=archlinux signature"`
+	Scripts   ArchLinuxScripts   `yaml:"scripts,omitempty" json:"scripts,omitempty" jsonschema:"title=archlinux-specific scripts"`
+}
+
+type ArchLinuxSignature struct {
+	PackageSignature `yaml:",inline" json:",inline"`
 }
 
 type ArchLinuxScripts struct {
@@ -410,7 +423,7 @@ type PackageSignature struct {
 	KeyID         *string `yaml:"key_id,omitempty" json:"key_id,omitempty" jsonschema:"title=key id,example=bc8acdd415bd80b3"`
 	KeyPassphrase string  `yaml:"-" json:"-"` // populated from environment variable
 	// SignFn, if set, will be called with the package-specific data to sign.
-	// For deb and rpm packages, data is the full package content.
+	// For deb, rpm and archlinux packages, data is the full package content.
 	// For apk packages, data is the SHA1 digest of control tgz.
 	//
 	// This allows for signing implementations other than using a local file

--- a/nfpm.go
+++ b/nfpm.go
@@ -243,15 +243,18 @@ func (c *Config) expandEnvVars() {
 	c.Deb.Signature.KeyFile = os.Expand(c.Deb.Signature.KeyFile, c.envMappingFunc)
 	c.RPM.Signature.KeyFile = os.Expand(c.RPM.Signature.KeyFile, c.envMappingFunc)
 	c.APK.Signature.KeyFile = os.Expand(c.APK.Signature.KeyFile, c.envMappingFunc)
+	c.ArchLinux.Signature.KeyFile = os.Expand(c.ArchLinux.Signature.KeyFile, c.envMappingFunc)
 	c.Deb.Signature.KeyID = pointer.ToString(os.Expand(pointer.GetString(c.Deb.Signature.KeyID), c.envMappingFunc))
 	c.RPM.Signature.KeyID = pointer.ToString(os.Expand(pointer.GetString(c.RPM.Signature.KeyID), c.envMappingFunc))
 	c.APK.Signature.KeyID = pointer.ToString(os.Expand(pointer.GetString(c.APK.Signature.KeyID), c.envMappingFunc))
+	c.ArchLinux.Signature.KeyID = pointer.ToString(os.Expand(pointer.GetString(c.ArchLinux.Signature.KeyID), c.envMappingFunc))
 
 	// Package signing passphrase
 	generalPassphrase := os.Expand("$NFPM_PASSPHRASE", c.envMappingFunc)
 	c.Deb.Signature.KeyPassphrase = generalPassphrase
 	c.RPM.Signature.KeyPassphrase = generalPassphrase
 	c.APK.Signature.KeyPassphrase = generalPassphrase
+	c.ArchLinux.Signature.KeyPassphrase = generalPassphrase
 
 	debPassphrase := os.Expand("$NFPM_DEB_PASSPHRASE", c.envMappingFunc)
 	if debPassphrase != "" {
@@ -266,6 +269,11 @@ func (c *Config) expandEnvVars() {
 	apkPassphrase := os.Expand("$NFPM_APK_PASSPHRASE", c.envMappingFunc)
 	if apkPassphrase != "" {
 		c.APK.Signature.KeyPassphrase = apkPassphrase
+	}
+
+	archlinuxPassphrase := os.Expand("$NFPM_ARCHLINUX_PASSPHRASE", c.envMappingFunc)
+	if archlinuxPassphrase != "" {
+		c.ArchLinux.Signature.KeyPassphrase = archlinuxPassphrase
 	}
 
 	// RPM specific
@@ -378,10 +386,15 @@ type Overridables struct {
 }
 
 type ArchLinux struct {
-	Pkgbase  string           `yaml:"pkgbase,omitempty" json:"pkgbase,omitempty" jsonschema:"title=explicitly specify the name used to refer to a split package, defaults to name"`
-	Arch     string           `yaml:"arch,omitempty" json:"arch,omitempty" jsonschema:"title=architecture in archlinux nomenclature"`
-	Packager string           `yaml:"packager,omitempty" json:"packager,omitempty" jsonschema:"title=organization that packaged the software"`
-	Scripts  ArchLinuxScripts `yaml:"scripts,omitempty" json:"scripts,omitempty" jsonschema:"title=archlinux-specific scripts"`
+	Pkgbase   string             `yaml:"pkgbase,omitempty" json:"pkgbase,omitempty" jsonschema:"title=explicitly specify the name used to refer to a split package, defaults to name"`
+	Arch      string             `yaml:"arch,omitempty" json:"arch,omitempty" jsonschema:"title=architecture in archlinux nomenclature"`
+	Packager  string             `yaml:"packager,omitempty" json:"packager,omitempty" jsonschema:"title=organization that packaged the software"`
+	Signature ArchLinuxSignature `yaml:"signature,omitempty" json:"signature,omitempty" jsonschema:"title=archlinux signature"`
+	Scripts   ArchLinuxScripts   `yaml:"scripts,omitempty" json:"scripts,omitempty" jsonschema:"title=archlinux-specific scripts"`
+}
+
+type ArchLinuxSignature struct {
+	PackageSignature `yaml:",inline" json:",inline"`
 }
 
 type ArchLinuxScripts struct {
@@ -421,7 +434,7 @@ type PackageSignature struct {
 	KeyID         *string `yaml:"key_id,omitempty" json:"key_id,omitempty" jsonschema:"title=key id,example=bc8acdd415bd80b3"`
 	KeyPassphrase string  `yaml:"-" json:"-"` // populated from environment variable
 	// SignFn, if set, will be called with the package-specific data to sign.
-	// For deb and rpm packages, data is the full package content.
+	// For deb, rpm and archlinux packages, data is the full package content.
 	// For apk packages, data is the SHA1 digest of control tgz.
 	//
 	// This allows for signing implementations other than using a local file

--- a/testdata/acceptance/archlinux.dockerfile
+++ b/testdata/acceptance/archlinux.dockerfile
@@ -75,8 +75,12 @@ RUN test ! -d /usr/foo/bar/something
 
 # ---- signed test ----
 FROM min AS signed
-RUN echo "Arch Linux has no signature support"
-
+COPY ${package}.sig /tmp/foo.pkg.tar.zst.sig
+COPY keys/pubkey.asc /tmp/pubkey.asc
+RUN pacman-key --init
+RUN pacman-key --add /tmp/pubkey.asc
+RUN pacman-key --lsign-key 866F6C83BAB3E49381ADE4C1BC8ACDD415BD80B3
+RUN pacman-key --verify /tmp/foo.pkg.tar.zst.sig 2>&1 | grep "gpg: Good signature from \"nfpm test key <test@example.com>\" \[full\]"
 
 # ---- overrides test ----
 FROM min AS overrides

--- a/testdata/acceptance/core.signed.yaml
+++ b/testdata/acceptance/core.signed.yaml
@@ -19,3 +19,6 @@ rpm:
 apk:
   signature:
     key_file: ./internal/sign/testdata/rsa_unprotected.priv
+archlinux:
+  signature:
+    key_file: ./internal/sign/testdata/privkey_unprotected.asc

--- a/www/content/docs/configuration.md
+++ b/www/content/docs/configuration.md
@@ -507,6 +507,18 @@ archlinux:
     # The postupgrade script runs after pacman upgrades the package
     postupgrade: ./scripts/postupgrade.sh
 
+  # The package is signed if a key_file is set
+  signature:
+    # PGP secret key, the passphrase is taken from the environment variable $NFPM_ARCHLINUX_PASSPHRASE with
+    # a fallback to $NFPM_PASSPHRASE.
+    # This will expand any env var you set in the field, e.g. key_file: ${SIGNING_KEY_FILE}
+    key_file: key.gpg
+
+    # PGP secret key id in hex format, if it is not set it will select the first subkey
+    # that has the signing flag set. You may need to set this if you want to use the primary key as the signing key.
+    # This will expand any env var you set in the field, e.g. key_id: ${ARCHLINUX_SIGNING_KEY_ID}
+    key_id: bc8acdd415bd80b3
+
 # Custom configuration applied only to the IPK packager (OpenWrt).
 ipk:
   # ipk specific architecture name that overrides "arch" without performing any replacements.

--- a/www/content/docs/configuration.md
+++ b/www/content/docs/configuration.md
@@ -513,6 +513,18 @@ archlinux:
     # The postupgrade script runs after pacman upgrades the package
     postupgrade: ./scripts/postupgrade.sh
 
+  # The package is signed if a key_file is set
+  signature:
+    # PGP secret key, the passphrase is taken from the environment variable $NFPM_ARCHLINUX_PASSPHRASE with
+    # a fallback to $NFPM_PASSPHRASE.
+    # This will expand any env var you set in the field, e.g. key_file: ${SIGNING_KEY_FILE}
+    key_file: key.gpg
+
+    # PGP secret key id in hex format, if it is not set it will select the first subkey
+    # that has the signing flag set. You may need to set this if you want to use the primary key as the signing key.
+    # This will expand any env var you set in the field, e.g. key_id: ${ARCHLINUX_SIGNING_KEY_ID}
+    key_id: bc8acdd415bd80b3
+
 # Custom configuration applied only to the IPK packager (OpenWrt).
 ipk:
   # ipk specific architecture name that overrides "arch" without performing any replacements.

--- a/www/static/schema.json
+++ b/www/static/schema.json
@@ -77,6 +77,10 @@
 						"type": "string",
 						"title": "organization that packaged the software"
 					},
+					"signature": {
+						"$ref": "#/$defs/ArchLinuxSignature",
+						"title": "archlinux signature"
+					},
 					"scripts": {
 						"$ref": "#/$defs/ArchLinuxScripts",
 						"title": "archlinux-specific scripts"
@@ -94,6 +98,26 @@
 					"postupgrade": {
 						"type": "string",
 						"title": "postupgrade script"
+					}
+				},
+				"additionalProperties": false,
+				"type": "object"
+			},
+			"ArchLinuxSignature": {
+				"properties": {
+					"key_file": {
+						"type": "string",
+						"title": "key file",
+						"examples": [
+							"key.gpg"
+						]
+					},
+					"key_id": {
+						"type": "string",
+						"title": "key id",
+						"examples": [
+							"bc8acdd415bd80b3"
+						]
 					}
 				},
 				"additionalProperties": false,


### PR DESCRIPTION
Archlinux packages can now be signed with a detached PGP signature, producing a binary .sig file alongside the package — matching the format expected by pacman-key --verify.

The signing reads back the finalized .pkg.tar.zst from disk via info.Target to avoid buffering the entire package in memory. The passphrase is taken from $NFPM_ARCHLINUX_PASSPHRASE with a fallback to $NFPM_PASSPHRASE, consistent with deb/rpm/apk.

Also adds sign.PGPDetachedSignWithKeyID, a streaming variant of PGPSignerWithKeyID that accepts an io.Reader instead of []byte.

See #628