### PR TITLE
fix: include RPM doc/licence/readme files in non-RPM packages

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -335,11 +335,14 @@ func isRelevantForPackager(packager string, content *Content) bool {
 	}
 
 	if packager != "rpm" &&
-		(content.Type == TypeRPMDoc || content.Type == TypeRPMLicence ||
-			content.Type == TypeRPMLicense || content.Type == TypeRPMReadme ||
-			content.Type == TypeRPMGhost) {
+		content.Type == TypeRPMGhost {
+		// Ghost files only apply to RPM; exclude from other packagers.
 		return false
 	}
+
+	// RPM-specific document types (doc, licence, license, readme) are treated
+	// as normal files by non-RPM packagers per documentation, so they are NOT
+	// excluded here.
 
 	if packager != "deb" && content.Type == TypeDebChangelog {
 		return false


### PR DESCRIPTION
Fixes #1037

## Problem

Files with `type: doc`, `type: licence`, `type: license`, or `type: readme` are completely excluded from deb and apk packages. The documentation states these RPM-specific types should be "ignored" (treated as normal files) by other packagers.

`isRelevantForPackager` returns `false` for all these types when the packager is not "rpm", causing them to be filtered out entirely.

## Fix

Only exclude `TypeRPMGhost` from non-RPM packagers (ghost files have no actual content, so exclusion makes sense). Doc/licence/license/readme types are no longer excluded, allowing them to be treated as normal files per the documentation.

This matches the documented behavior:
> "For packagers other than RPM, [...] the remaining RPM-specific types are the same as '', a normal file."