### PR TITLE
fix: tolerate empty overrides packager clause

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"os"
 	"slices"
 	"sort"
@@ -211,13 +212,17 @@ func (c *Config) expandEnvVars() {
 	c.Platform = os.Expand(c.Platform, c.envMappingFunc)
 	c.Arch = os.Expand(c.Arch, c.envMappingFunc)
 	for or := range c.Overrides {
-		c.Overrides[or].Conflicts = c.expandEnvVarsStringSlice(c.Overrides[or].Conflicts)
-		c.Overrides[or].Depends = c.expandEnvVarsStringSlice(c.Overrides[or].Depends)
-		c.Overrides[or].Replaces = c.expandEnvVarsStringSlice(c.Overrides[or].Replaces)
-		c.Overrides[or].Recommends = c.expandEnvVarsStringSlice(c.Overrides[or].Recommends)
-		c.Overrides[or].Provides = c.expandEnvVarsStringSlice(c.Overrides[or].Provides)
-		c.Overrides[or].Suggests = c.expandEnvVarsStringSlice(c.Overrides[or].Suggests)
-		c.Overrides[or].Contents = c.expandEnvVarsContents(c.Overrides[or].Contents)
+		if c.Overrides[or] == nil {
+			log.Printf("warning: override '%s' is empty; ignoring", or)
+		} else {
+			c.Overrides[or].Conflicts = c.expandEnvVarsStringSlice(c.Overrides[or].Conflicts)
+			c.Overrides[or].Depends = c.expandEnvVarsStringSlice(c.Overrides[or].Depends)
+			c.Overrides[or].Replaces = c.expandEnvVarsStringSlice(c.Overrides[or].Replaces)
+			c.Overrides[or].Recommends = c.expandEnvVarsStringSlice(c.Overrides[or].Recommends)
+			c.Overrides[or].Provides = c.expandEnvVarsStringSlice(c.Overrides[or].Provides)
+			c.Overrides[or].Suggests = c.expandEnvVarsStringSlice(c.Overrides[or].Suggests)
+			c.Overrides[or].Contents = c.expandEnvVarsContents(c.Overrides[or].Contents)
+		}
 	}
 	c.Conflicts = c.expandEnvVarsStringSlice(c.Conflicts)
 	c.Depends = c.expandEnvVarsStringSlice(c.Depends)

--- a/nfpm.go
+++ b/nfpm.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"slices"
 	"sort"
@@ -213,16 +212,15 @@ func (c *Config) expandEnvVars() {
 	c.Arch = os.Expand(c.Arch, c.envMappingFunc)
 	for or := range c.Overrides {
 		if c.Overrides[or] == nil {
-			log.Printf("warning: override '%s' is empty; ignoring", or)
-		} else {
-			c.Overrides[or].Conflicts = c.expandEnvVarsStringSlice(c.Overrides[or].Conflicts)
-			c.Overrides[or].Depends = c.expandEnvVarsStringSlice(c.Overrides[or].Depends)
-			c.Overrides[or].Replaces = c.expandEnvVarsStringSlice(c.Overrides[or].Replaces)
-			c.Overrides[or].Recommends = c.expandEnvVarsStringSlice(c.Overrides[or].Recommends)
-			c.Overrides[or].Provides = c.expandEnvVarsStringSlice(c.Overrides[or].Provides)
-			c.Overrides[or].Suggests = c.expandEnvVarsStringSlice(c.Overrides[or].Suggests)
-			c.Overrides[or].Contents = c.expandEnvVarsContents(c.Overrides[or].Contents)
+			continue
 		}
+		c.Overrides[or].Conflicts = c.expandEnvVarsStringSlice(c.Overrides[or].Conflicts)
+		c.Overrides[or].Depends = c.expandEnvVarsStringSlice(c.Overrides[or].Depends)
+		c.Overrides[or].Replaces = c.expandEnvVarsStringSlice(c.Overrides[or].Replaces)
+		c.Overrides[or].Recommends = c.expandEnvVarsStringSlice(c.Overrides[or].Recommends)
+		c.Overrides[or].Provides = c.expandEnvVarsStringSlice(c.Overrides[or].Provides)
+		c.Overrides[or].Suggests = c.expandEnvVarsStringSlice(c.Overrides[or].Suggests)
+		c.Overrides[or].Contents = c.expandEnvVarsContents(c.Overrides[or].Contents)
 	}
 	c.Conflicts = c.expandEnvVarsStringSlice(c.Conflicts)
 	c.Depends = c.expandEnvVarsStringSlice(c.Depends)

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -324,6 +324,8 @@ func TestParseFile(t *testing.T) {
 	require.Equal(t, "my/rpm/key/file", config.RPM.Signature.KeyFile)
 	require.Equal(t, "hard/coded/file", config.Deb.Signature.KeyFile)
 	require.Empty(t, config.APK.Signature.KeyFile)
+	_, err = parseAndValidate("./testdata/overrides-missing.yaml")
+	require.NoError(t, err)
 }
 
 func TestParseEnhancedFile(t *testing.T) {

--- a/testdata/overrides-missing.yaml
+++ b/testdata/overrides-missing.yaml
@@ -1,0 +1,32 @@
+# Configuration file used to test that missing overrides don't cause a
+# segmentation fault.  See `overrides.deb` below.
+name: "foo"
+arch: "amd64"
+mtime: 2023-01-02
+version: "v1.2.3"
+contents:
+  - src: ./testdata/whatever.conf
+    dst: /etc/foo/whatever.conf
+    type: config
+  - src: ./testdata/whatever.conf
+    dst: /deb/path.conf
+    type: config
+    packager: deb
+  - src: ./testdata/whatever.conf
+    dst: /rpm/path.conf
+    type: config
+    packager: rpm
+  - src: ./testdata/whatever.conf
+    dst: /apk/path.conf
+    type: config
+    packager: apk
+rpm:
+  group: foo
+overrides:
+  deb:
+  rpm:
+    depends:
+      - rpm_depend
+  apk:
+    depends:
+      - apk_depend


### PR DESCRIPTION
Addresses #1079.

If an `overrides.$packager` clause is empty in the configuration, this is detected and a warning issued instead of producing a segmentation violation.

I only dabble in Go from time to time so apologies if the code isn't up to standard.