### PR TITLE
srpm: set rpmpack SourceRPM metadata flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,3 +95,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.7.1 // indirect
 )
+
+replace github.com/google/rpmpack => github.com/alexma233/rpmpack v0.7.2-0.20260501025250-ba11ef02e94a

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f h1:tCbYj7/299ek
 github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f/go.mod h1:gcr0kNtGBqin9zDW9GOHcVntrwnjrK+qdJ06mWYBybw=
 github.com/ProtonMail/gopenpgp/v2 v2.7.1 h1:Awsg7MPc2gD3I7IFac2qE3Gdls0lZW8SzrFZ3k1oz0s=
 github.com/ProtonMail/gopenpgp/v2 v2.7.1/go.mod h1:/BU5gfAVwqyd8EfC3Eu7zmuhwYQpKs+cGD8M//iiaxs=
+github.com/alexma233/rpmpack v0.7.2-0.20260501025250-ba11ef02e94a h1:goLwLgxCzcetDmCFdkoSl+jC5W2obmuRGqKbfHB8KSU=
+github.com/alexma233/rpmpack v0.7.2-0.20260501025250-ba11ef02e94a/go.mod h1:J4Kede8+51GsEvWLKahp9zBD/Vyw426pjsubcobH9ec=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -97,8 +99,6 @@ github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8J
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/rpmpack v0.7.1 h1:YdWh1IpzOjBz60Wvdw0TU0A5NWP+JTVHA5poDqwMO2o=
-github.com/google/rpmpack v0.7.1/go.mod h1:h1JL16sUTWCLI/c39ox1rDaTBo3BXUQGjczVJyK4toU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=

--- a/rpm/rpm.go
+++ b/rpm/rpm.go
@@ -143,6 +143,9 @@ func (r *RPM) Package(info *nfpm.Info, w io.Writer) (err error) {
 	if meta, err = buildRPMMeta(info); err != nil {
 		return err
 	}
+	if r.format == formatSRPM {
+		meta.SourceRPM = true
+	}
 	if rpm, err = rpmpack.NewRPM(*meta); err != nil {
 		return err
 	}


### PR DESCRIPTION
When building source RPMs, the `SOURCERPM` (RPMTAG_SOURCERPM, 1044) tag must not be present.  RPM utilities treat its presence as indicating a binary (non-source) RPM.  This causes build services like Fedora COPR to reject source RPMs generated by the `srpm` packager.

The upstream rpmpack (google/rpmpack#105) adds a `SourceRPM` field to `RPMMetaData` that controls whether `SOURCERPM` is written.  This PR:

- Sets `meta.SourceRPM = true` when the packager format is `srpm`
- Uses a `replace` directive pointing to the rpmpack fork with the new field

### Dependency

Depends on https://github.com/google/rpmpack/pull/105 being merged and released.

The `replace` directive in `go.mod` should be removed and the rpmpack dependency bumped once a new release is available.

### Verification

- `go test ./rpm/...` — 73 tests pass, including `TestSRPM`
- Generated SRPM no longer contains the `SOURCERPM` tag header