### PR TITLE
fix(rpm): escape % in generated SRPM spec so scriptlets survive rebuild

### DIFF
--- a/rpm/changelog.go
+++ b/rpm/changelog.go
@@ -102,8 +102,8 @@ func renderSpecChangelog(info *nfpm.Info) (string, error) {
 	var b strings.Builder
 	b.WriteString("\n%changelog\n")
 	for _, e := range entries {
-		fmt.Fprintf(&b, "* %s %s\n", e.when.Format("Mon Jan 02 2006"), e.title)
-		b.WriteString(e.notes)
+		fmt.Fprintf(&b, "* %s %s\n", e.when.Format("Mon Jan 02 2006"), escapeSpecText(e.title))
+		b.WriteString(escapeSpecText(e.notes))
 		b.WriteString("\n\n")
 	}
 	return b.String(), nil

--- a/rpm/spec.go
+++ b/rpm/spec.go
@@ -28,7 +28,7 @@ func generateSpec(info *nfpm.Info, sourceName string) (string, error) {
 
 	writeField := func(key, value string) {
 		if value != "" {
-			fmt.Fprintf(&b, "%s: %s\n", key, value)
+			fmt.Fprintf(&b, "%s: %s\n", key, escapeSpecText(value))
 		}
 	}
 
@@ -76,7 +76,7 @@ func generateSpec(info *nfpm.Info, sourceName string) (string, error) {
 
 	fmt.Fprintf(&b, "Source0: %s\n", sourceName)
 
-	fmt.Fprintf(&b, "\n%%description\n%s\n", description)
+	fmt.Fprintf(&b, "\n%%description\n%s\n", escapeSpecText(description))
 
 	b.WriteString("\n%prep\n")
 	b.WriteString("\n%build\n")
@@ -114,6 +114,7 @@ func writeScriptSection(b *strings.Builder, section, body string) {
 	if body == "" {
 		return
 	}
+	body = escapeSpecText(body)
 	fmt.Fprintf(b, "\n%%%s\n%s", section, body)
 	if !strings.HasSuffix(body, "\n") {
 		b.WriteString("\n")
@@ -133,7 +134,7 @@ func writeFilesSection(b *strings.Builder, info *nfpm.Info) {
 }
 
 func specFileLine(content *files.Content) string {
-	dest := files.ToNixPath(content.Destination)
+	dest := escapeSpecText(files.ToNixPath(content.Destination))
 	owner := defaultTo(content.FileInfo.Owner, "root")
 	group := defaultTo(content.FileInfo.Group, "root")
 
@@ -179,4 +180,12 @@ func specFileLine(content *files.Content) string {
 // section, normalizing the mode to its octal RPM representation.
 func attrPath(mode fs.FileMode, owner, group, dest string) string {
 	return fmt.Sprintf("%%attr(%04o, %s, %s) %q", normalizeFileMode(mode), owner, group, dest)
+}
+
+// escapeSpecText doubles every percent sign so that rpmbuild treats the value
+// as literal text when the generated SRPM is rebuilt, instead of expanding
+// %macro / %(command) / %% sequences. Apply it to user-controlled content only,
+// never to the spec directives nfpm itself emits.
+func escapeSpecText(s string) string {
+	return strings.ReplaceAll(s, "%", "%%")
 }

--- a/rpm/srpm_test.go
+++ b/rpm/srpm_test.go
@@ -2,6 +2,8 @@ package rpm
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/goreleaser/nfpm/v2"
@@ -198,4 +200,49 @@ func TestSRPMGenerateSpecLang(t *testing.T) {
 	require.Contains(t, spec, "/usr/share/locale/en/LC_MESSAGES/langtest.mo")
 	require.Contains(t, spec, "%lang(fr) %config %attr")
 	require.Contains(t, spec, "/etc/langtest.conf")
+}
+
+// TestSRPMGenerateSpecEscapesPercent guards against user content being
+// reinterpreted by rpmbuild on rebuild: every percent sign in scriptlets,
+// free-text fields and file paths must be doubled so it stays literal.
+func TestSRPMGenerateSpecEscapesPercent(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "postinstall.sh")
+	// ${HOST%%.*} is the common longest-suffix-strip idiom; %{_libdir} and
+	// %(id -u) are macro/command forms. All must survive a rebuild verbatim.
+	require.NoError(t, os.WriteFile(script,
+		[]byte("#!/bin/sh\nshort=${HOST%%.*}\necho %{_libdir} %(id -u)\n"), 0o755))
+
+	info := nfpm.WithDefaults(&nfpm.Info{
+		Name:        "esc",
+		Arch:        "amd64",
+		Version:     "1.0.0",
+		Description: "desc with %{_libdir} and %(echo hi)",
+		Maintainer:  "maintainer",
+		Overridables: nfpm.Overridables{
+			Scripts: nfpm.Scripts{PostInstall: script},
+			RPM:     nfpm.RPM{Summary: "summary 50% off"},
+			Contents: []*files.Content{
+				{Source: "../testdata/whatever.conf", Destination: "/etc/foo%bar.conf"},
+			},
+		},
+	})
+	info = setDefaults(info)
+	require.NoError(t, nfpm.PrepareForPackager(info, "rpm"))
+
+	spec, err := generateSpec(info, "esc-1.0.0.tar.gz")
+	require.NoError(t, err)
+
+	// Percent signs in user content are doubled; the bare ${HOST%.*} would
+	// silently strip the shortest suffix instead of the longest on rebuild.
+	require.Contains(t, spec, "short=${HOST%%%%.*}")
+	require.Contains(t, spec, "echo %%{_libdir} %%(id -u)")
+	require.Contains(t, spec, "Summary: summary 50%% off")
+	require.Contains(t, spec, "%description\ndesc with %%{_libdir} and %%(echo hi)")
+	require.Contains(t, spec, `/etc/foo%%bar.conf`)
+	require.NotContains(t, spec, "short=${HOST%.*}")
+
+	// Directives nfpm emits itself stay single-percent and functional.
+	require.Contains(t, spec, "%global debug_package %{nil}")
+	require.Contains(t, spec, "tar -C %{buildroot} -xf %{SOURCE0}")
 }

--- a/testdata/acceptance/srpm.dockerfile
+++ b/testdata/acceptance/srpm.dockerfile
@@ -32,6 +32,9 @@ RUN rpm -qp --qf '[%{FILENAMES} %{FILEFLAGS}\n]' /tmp/foo.rpm | grep -E '^/var/l
 RUN test "$(rpm -qp --provides /tmp/foo.rpm | grep '^foo-tool$')" = "foo-tool"
 RUN rpm -qp --requires /tmp/foo.rpm | grep -E '^bash$'
 RUN rpm -qp --scripts /tmp/foo.rpm | grep -E 'postinstall scriptlet'
+# %-sequences in scriptlets must survive the rebuild literally; without the
+# spec escaping, ${host%%.*} would be silently mangled to ${host%.*}.
+RUN rpm -qp --scripts /tmp/foo.rpm | grep -F '${host%%.*}'
 
 # Install it and verify the payload landed on disk.
 RUN rpm -ivh /tmp/foo.rpm

--- a/testdata/acceptance/srpm.rebuild.yaml
+++ b/testdata/acceptance/srpm.rebuild.yaml
@@ -32,7 +32,7 @@ contents:
   - dst: /var/lib/foo/state
     type: ghost
 scripts:
-  postinstall: ./testdata/scripts/postinstall.sh
+  postinstall: ./testdata/scripts/srpm-rebuild-postinstall.sh
 rpm:
   group: "Application/Misc"
   summary: "foo summary"

--- a/testdata/scripts/srpm-rebuild-postinstall.sh
+++ b/testdata/scripts/srpm-rebuild-postinstall.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# The longest-suffix-strip idiom must survive `rpmbuild --rebuild` verbatim.
+# Without %-escaping in the generated spec, ${host%%.*} is silently mangled to
+# ${host%.*}, which strips the shortest suffix instead of the longest.
+host="server.example.com"
+echo "${host%%.*}" > /dev/null


### PR DESCRIPTION
Follow-up to #1104 (now merged): a correctness fix in the new SRPM path.

### Problem

`generateSpec` inlined user-controlled content verbatim into the generated
`.spec` file. RPM treats `%` specially, so any `%`-sequence is reinterpreted
when the SRPM is rebuilt with `rpmbuild --rebuild`:

- `%%` collapses to a single `%`
- `%{macro}` is expanded (e.g. `%{_libdir}` → `/usr/lib64`)
- `%(command)` is executed at build time

The most common real-world hit is the bash longest-suffix-strip idiom: a
scriptlet containing `${VAR%%.*}` was silently rebuilt as `${VAR%.*}`
(shortest suffix), changing install/upgrade/removal script behavior with no
warning. Affected inputs: scriptlets, `%description`, free-text preamble
fields (Summary/Group/Vendor/…), dependency strings, `%files` paths, and the
`%changelog`.

Binary RPMs are **not** affected — their scriptlets/description go straight
into header tags with no spec parsing — so this is scoped to the SRPM path.

### Fix

Add `escapeSpecText`, which doubles every `%` in user-controlled spec text so
`rpmbuild` restores it literally on rebuild. Doubling round-trips correctly
(`rpmbuild` collapses each `%%` back to `%`). Spec directives nfpm emits
itself (`%global`, `%install`, `%attr(...)`, …) are left untouched.

### Tests

- New unit test `TestSRPMGenerateSpecEscapesPercent` asserting scriptlets,
  description, summary and file paths are escaped.
- The srpm rebuild acceptance test now ships a `${host%%.*}` scriptlet and
  asserts it survives the real `rpmbuild --rebuild` (it previously contained
  no `%` and so could not catch this).

`go build ./...`, `go test ./...`, `gofumpt` and `golangci-lint` all pass.
