### PR TITLE
fix(apk): normalize file modes before writing tar headers

### DIFF
--- a/apk/apk.go
+++ b/apk/apk.go
@@ -36,6 +36,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"io/fs"
 	"net/mail"
 	"os"
 	"strings"
@@ -419,7 +420,7 @@ func createFilesInsideTarGz(info *nfpm.Info, tw *tar.Writer, sizep *int64) (err 
 		case files.TypeDir, files.TypeImplicitDir:
 			err = tw.WriteHeader(&tar.Header{
 				Name:     file.Destination,
-				Mode:     int64(file.FileInfo.Mode),
+				Mode:     int64(normalizeFileMode(file.FileInfo.Mode)),
 				Typeflag: tar.TypeDir,
 				Uname:    file.FileInfo.Owner,
 				Gname:    file.FileInfo.Group,
@@ -453,9 +454,9 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, sizep *int64) error
 		return err
 	}
 
-	// tar.FileInfoHeader only uses file.Mode().Perm() which masks the mode with
-	// 0o777 which we don't want because we want to be able to set the suid bit.
-	header.Mode = int64(file.Mode())
+	// Preserve Unix special bits without leaking Go's file type flags into the
+	// tar mode field.
+	header.Mode = int64(normalizeFileMode(file.Mode()))
 	header.Name = files.AsRelativePath(file.Destination)
 	header.Uname = file.FileInfo.Owner
 	header.Gname = file.FileInfo.Group
@@ -465,6 +466,20 @@ func copyToTarAndDigest(file *files.Content, tw *tar.Writer, sizep *int64) error
 
 	*sizep += file.Size()
 	return nil
+}
+
+func normalizeFileMode(mode fs.FileMode) fs.FileMode {
+	result := mode & 0o7777
+	if mode&fs.ModeSetuid != 0 {
+		result |= 0o4000
+	}
+	if mode&fs.ModeSetgid != 0 {
+		result |= 0o2000
+	}
+	if mode&fs.ModeSticky != 0 {
+		result |= 0o1000
+	}
+	return result
 }
 
 // reference: https://wiki.adelielinux.org/wiki/APK_internals#.PKGINFO

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -642,7 +642,7 @@ func TestTreeDirectoryMode(t *testing.T) {
 	sourceInfo, err := os.Stat(source)
 	require.NoError(t, err)
 	require.Equal(t, byte(tar.TypeDir), header.Typeflag)
-	require.Equal(t, int64(sourceInfo.Mode().Perm()), header.Mode)
+	require.Equal(t, int64(sourceInfo.Mode().Perm()&^info.Umask), header.Mode)
 	require.NotEqual(t, tar.FormatGNU, header.Format)
 }
 

--- a/apk/apk_test.go
+++ b/apk/apk_test.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -614,6 +615,82 @@ func TestDirectories(t *testing.T) {
 	require.Equal(t, "test", h.Uname)
 	h = extractFileHeaderFromTar(t, buf.Bytes(), "/etc/baz")
 	require.Equal(t, h.Typeflag, byte(tar.TypeDir))
+}
+
+func TestTreeDirectoryMode(t *testing.T) {
+	source := t.TempDir()
+	require.NoError(t, os.Chmod(source, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(source, "hello.txt"), []byte("hello\n"), 0o644))
+
+	info := exampleInfo()
+	info.Contents = []*files.Content{
+		{
+			Source:      source,
+			Destination: "/usr/lib/repro",
+			Type:        files.TypeTree,
+		},
+	}
+	require.NoError(t, nfpm.PrepareForPackager(info, "apk"))
+
+	var buf bytes.Buffer
+	size := int64(0)
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, createFilesInsideTarGz(info, tw, &size))
+	require.NoError(t, tw.Close())
+
+	header := extractFileHeaderFromTar(t, buf.Bytes(), "/usr/lib/repro")
+	sourceInfo, err := os.Stat(source)
+	require.NoError(t, err)
+	require.Equal(t, byte(tar.TypeDir), header.Typeflag)
+	require.Equal(t, int64(sourceInfo.Mode().Perm()), header.Mode)
+	require.NotEqual(t, tar.FormatGNU, header.Format)
+}
+
+func TestNormalizeFileMode(t *testing.T) {
+	tests := map[string]struct {
+		mode fs.FileMode
+		want fs.FileMode
+	}{
+		"permissions":          {mode: 0o755, want: 0o755},
+		"directory type":       {mode: fs.ModeDir | 0o755, want: 0o755},
+		"Go setuid":            {mode: fs.ModeSetuid | 0o755, want: 0o4755},
+		"Go setgid":            {mode: fs.ModeSetgid | 0o755, want: 0o2755},
+		"Go sticky":            {mode: fs.ModeSticky | 0o755, want: 0o1755},
+		"octal special bits":   {mode: 0o7755, want: 0o7755},
+		"unrelated type flags": {mode: fs.ModeSymlink | 0o777, want: 0o777},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.want, normalizeFileMode(tt.mode))
+		})
+	}
+}
+
+func TestCopyToTarAndDigestNormalizesSpecialModeBits(t *testing.T) {
+	contents := []byte("hello\n")
+	source := filepath.Join(t.TempDir(), "hello.txt")
+	require.NoError(t, os.WriteFile(source, contents, 0o644))
+
+	file := &files.Content{
+		Source:      source,
+		Destination: "/usr/bin/hello",
+		Type:        files.TypeFile,
+		FileInfo: &files.ContentFileInfo{
+			Mode: fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky | 0o755,
+			Size: int64(len(contents)),
+		},
+	}
+
+	var buf bytes.Buffer
+	size := int64(0)
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, copyToTarAndDigest(file, tw, &size))
+	require.NoError(t, tw.Close())
+
+	header := extractFileHeaderFromTar(t, buf.Bytes(), file.Destination)
+	require.Equal(t, fs.FileMode(0o7755), fs.FileMode(header.Mode))
+	require.Equal(t, int64(len(contents)), size)
 }
 
 func TestNoDuplicateAutocreatedDirectories(t *testing.T) {


### PR DESCRIPTION
## Summary

- normalize Go `fs.FileMode` values before writing APK tar headers
- preserve configured and Go-encoded setuid, setgid, and sticky bits
- cover walked tree directories and regular-file special modes

## Why

`type: tree` directories carry Go's `ModeDir` flag in `FileInfo.Mode`. Writing that raw value overflows tar's octal mode field, switches the header to GNU/base-256 encoding, and makes apk-tools reject the package.

Fixes #1112

## Validation

- `GOTOOLCHAIN=go1.26.4 go test -race ./... -timeout=5m` - passed
- `GOTOOLCHAIN=go1.26.4 go vet ./...` - passed
- `golangci-lint v2.12.2 run --timeout=5m` - passed
- `DOCKER_BUILDKIT=1 GOTOOLCHAIN=go1.26.4 go test -tags=acceptance -p 1 -race acceptance_test.go -run '^TestCore/apk/amd64/complex$'` - passed
- `apk add --allow-untrusted repro-tree_1.0.0_x86_64.apk` on Alpine 3.20 - failed before with `v2 package format error`; passed after with the payload installed
