### PR TITLE
fix: don't panic in Config.Get on an empty override clause

### DIFF
--- a/nfpm.go
+++ b/nfpm.go
@@ -145,8 +145,8 @@ func (c *Config) Get(format string) (info *Info, err error) {
 		return nil, fmt.Errorf("failed to merge config into info: %w", err)
 	}
 	override, ok := c.Overrides[format]
-	if !ok {
-		// no overrides
+	if !ok || override == nil {
+		// no overrides, or an empty override clause (e.g. "overrides:\n  deb:")
 		return info, nil
 	}
 	if err = mergo.Merge(&info.Overridables, override, mergo.WithOverride); err != nil {

--- a/nfpm_test.go
+++ b/nfpm_test.go
@@ -324,7 +324,10 @@ func TestParseFile(t *testing.T) {
 	require.Equal(t, "my/rpm/key/file", config.RPM.Signature.KeyFile)
 	require.Equal(t, "hard/coded/file", config.Deb.Signature.KeyFile)
 	require.Empty(t, config.APK.Signature.KeyFile)
-	_, err = parseAndValidate("./testdata/overrides-missing.yaml")
+	missing, err := parseAndValidate("./testdata/overrides-missing.yaml")
+	require.NoError(t, err)
+	// an empty override clause (overrides.deb) must not panic when resolved
+	_, err = missing.Get("deb")
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
An `overrides.<packager>` entry can be written as an empty clause:

```yaml
overrides:
  deb:
```

which decodes to a nil `*Overridables`. `Config.Get` guards the missing-key case but not the present-but-nil case, so `mergo.Merge(&info.Overridables, override, ...)` panics on it.

Its reachable straight from the CLI: `internal/cmd/package.go` calls `config.Get(packager)`, so `nfpm package -f nfpm.yaml -p deb` on the config above crashes.

The repo already has a fixture for this class (`testdata/overrides-missing.yaml`, commented "test that missing overrides do not cause a segmentation fault"), and #1080 added the same nil guard in `expandEnvVars`. The `Get` path was left uncovered, and driving that fixture through `Get("deb")` still panics on current main:

```
panic: runtime error: invalid memory address or nil pointer dereference
  ... dario.cat/mergo.Merge ... nfpm.go:152 (*Config).Get
```

The fix mirrors the `expandEnvVars` guard (`|| override == nil`) and extends the existing `overrides-missing.yaml` test to also call `Get("deb")`, which is what the CLI does. `go test .` passes.